### PR TITLE
Improve Hetzner Cloud Terraform template

### DIFF
--- a/ansible/roles/infra-public-resources/defaults/main/hetzner.yaml
+++ b/ansible/roles/infra-public-resources/defaults/main/hetzner.yaml
@@ -43,6 +43,9 @@ infra_publicresources_hcloud_firewall:
           - "0.0.0.0/0"
           - "::/0"
       - protocol: icmp
+        ip_addresses:
+          - "0.0.0.0/0"
+          - "::/0"
     outbound:
       - protocol: tcp
         port_range: 80
@@ -55,6 +58,9 @@ infra_publicresources_hcloud_firewall:
           - "0.0.0.0/0"
           - "::/0"
       - protocol: icmp
+        ip_addresses:
+          - "0.0.0.0/0"
+          - "::/0"
 
 
 

--- a/ansible/roles/infra-public-resources/templates/hetzner.tf
+++ b/ansible/roles/infra-public-resources/templates/hetzner.tf
@@ -132,12 +132,18 @@ resource "hcloud_floating_ip_assignment" "{{ ipassignment.id }}" {
 #############################################################################
 # FIREWALLS
 #############################################################################
-{% if infra_publicresources_digitalocean_firewall is defined %}
-{% for firewall in infra_publicresources_digitalocean_firewall %}
+{% if infra_publicresources_hcloud_firewall is defined %}
+{% for firewall in infra_publicresources_hcloud_firewall %}
 {% if firewall.id is defined %}
 
 resource "hcloud_firewall" "{{ firewall.id }}" {
   name = "{{ firewall.id }}"
+
+  apply_to {
+  {% for tag in firewall.tags %}
+      label_selector = "{{ tag }}"{{ "," if not loop.last }}
+  {% endfor %}
+        }
 
   {% if firewall.inbound is defined %}
   {% for inbound in firewall.inbound %}
@@ -170,7 +176,7 @@ resource "hcloud_firewall" "{{ firewall.id }}" {
     {% endif %}
 
     {% if outbound.ip_addresses is defined %}
-    source_ips = [
+    destination_ips = [
       {% for ipaddress in outbound.ip_addresses %}
       "{{ ipaddress }}"{{ "," if not loop.last }}
       {% endfor %}


### PR DESCRIPTION
## Summary

- **Fix rrset grouping**: Records are now grouped by (hostname, type) into single `hcloud_zone_rrset` resources, as required by Hetzner's DNS API
- **Fix SSH key reference**: Changed `digitalocean_ssh_key` → `hcloud_ssh_key` in server resource
- **Fix firewall configuration**: 
  - Use correct variable `infra_publicresources_hcloud_firewall` instead of DigitalOcean's
  - Add `apply_to` block with label selector for tag-based firewall assignment
  - Fix outbound rules to use `destination_ips` instead of `source_ips`
- **Fix record value handling**: TXT records use `provider::hcloud::txt_record()`, MX/SRV prepend priority
- **Fix floating IP region**: `nbg1-dc3` → `nbg1`
- **Add ICMP IP addresses**: Required by Hetzner firewall rules

See #74 for remaining firewall improvements.

## Test plan

- [ ] Run Ansible playbook in check mode to verify template renders correctly
- [ ] Review generated Terraform plan for expected resources
- [ ] Verify rrsets are properly grouped (e.g., MX records consolidated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)