### PR TITLE
feat(composition-homeassistant): Amazon pickup IMAP notification

### DIFF
--- a/roles/composition-homeassistant/templates/ha/configuration.yaml
+++ b/roles/composition-homeassistant/templates/ha/configuration.yaml
@@ -107,6 +107,27 @@ logbook:
       - sun
 
 #############################################################################
+# AUTOMATIONS (INLINE)
+#############################################################################
+# Requires the IMAP integration to include `headers` in event message data.
+automation manual:
+  - alias: Amazon pickup notification
+    description: Notify Charlie's iPhone when a pickup-point@amazon.de email arrives.
+    triggers:
+      - trigger: event
+        event_type: imap_content
+    conditions:
+      - condition: template
+        value_template: >-
+          {{ 'pickup-point@amazon.de' in
+             (trigger.event.data.headers.get('Reply-To', []) | join(',') | lower) }}
+    actions:
+      - action: notify.mobile_app_charlies_iphone
+        data:
+          title: Amazon pickup ready
+          message: "{{ trigger.event.data.subject }}"
+
+#############################################################################
 # INCLUDES
 #############################################################################
 automation: !include automations.yaml

--- a/roles/composition-homeassistant/templates/ha/configuration.yaml
+++ b/roles/composition-homeassistant/templates/ha/configuration.yaml
@@ -119,7 +119,8 @@ automation manual:
     conditions:
       - condition: template
         value_template: >-
-          {{ 'pickup-point@amazon.de' in
+          {{ not trigger.event.data.initial and
+             'pickup-point@amazon.de' in
              (trigger.event.data.headers.get('Reply-To', []) | join(',') | lower) }}
     actions:
       - action: notify.mobile_app_charlies_iphone


### PR DESCRIPTION
## Summary
- Adds inline `automation manual:` block to the Home Assistant `configuration.yaml` that listens for `imap_content` events, matches `pickup-point@amazon.de` in the `Reply-To` header, and sends a notification to `notify.mobile_app_charlies_iphone`.
- Skips events where `trigger.event.data.initial` is true, so the automation only fires for newly delivered mail and not the unread-batch replay at HA startup.
- Uses the labelled `automation manual:` form since the default `automation:` key is already consumed by `!include automations.yaml`.

## Notes
- Requires the IMAP integration to be configured with `headers` in event message data, otherwise the Reply-To lookup returns an empty list.
- The notify service name assumes Charlie's HA companion device registers as `mobile_app_charlies_iphone` — adjust if the actual entity ID differs.

## Test plan
- [ ] Apply the composition-homeassistant role and confirm HA restarts cleanly with no YAML parse errors.
- [ ] Send a test email with `Reply-To: pickup-point@amazon.de` and verify Charlie's iPhone receives the notification.
- [ ] Restart HA with unread Amazon pickup mail in the inbox and confirm no notification fires (initial scan).
