### PR TITLE
Add composition-paperless-ngx role for storage server

### DIFF
--- a/inventory/host_vars/server-64gb-storage/core.yaml
+++ b/inventory/host_vars/server-64gb-storage/core.yaml
@@ -172,3 +172,4 @@ cnames:
   - translate.{{ domainname_infra }}
   - loki.{{ domainname_infra }}
   - chat.{{ domainname_infra }}
+  - paperless.{{ domainname_infra }}

--- a/inventory/host_vars/server-64gb-storage/vault_paperless_ngx.yaml
+++ b/inventory/host_vars/server-64gb-storage/vault_paperless_ngx.yaml
@@ -1,0 +1,5 @@
+# Encrypt this file with: ansible-vault encrypt inventory/host_vars/server-64gb-storage/vault_paperless_ngx.yaml
+vault_paperless_ngx_db_password: CHANGEME
+vault_paperless_ngx_secret_key: CHANGEME
+vault_paperless_ngx_admin_password: CHANGEME
+vault_paperless_ngx_admin_mail: CHANGEME

--- a/playbooks/hosts/server-64gb-storage/core.yaml
+++ b/playbooks/hosts/server-64gb-storage/core.yaml
@@ -77,6 +77,8 @@
       tags: [compositions, composition-n8n]
     - role: composition-memorybank
       tags: [compositions]
+    - role: composition-paperless-ngx
+      tags: [compositions]
     - role: system-emailbackup
       tags: [system]
     - role: system-smartmontools

--- a/roles/composition-paperless-ngx/defaults/main.yaml
+++ b/roles/composition-paperless-ngx/defaults/main.yaml
@@ -1,0 +1,11 @@
+# Composition name (used by composition-common dependency)
+composition_name: paperless-ngx
+
+composition_paperless_ngx_subdomains:
+  - paperless
+
+paperless_ngx_db_password: "{{ vault_paperless_ngx_db_password }}"
+paperless_ngx_secret_key: "{{ vault_paperless_ngx_secret_key }}"
+paperless_ngx_admin_user: admin
+paperless_ngx_admin_password: "{{ vault_paperless_ngx_admin_password }}"
+paperless_ngx_admin_mail: "{{ vault_paperless_ngx_admin_mail }}"

--- a/roles/composition-paperless-ngx/meta/main.yaml
+++ b/roles/composition-paperless-ngx/meta/main.yaml
@@ -1,0 +1,4 @@
+dependencies:
+  - role: composition-common
+    vars:
+      composition_name: paperless-ngx

--- a/roles/composition-paperless-ngx/tasks/main.yaml
+++ b/roles/composition-paperless-ngx/tasks/main.yaml
@@ -1,0 +1,56 @@
+# code: language=ansible
+
+# ----------------------------
+# Core tasks
+# ----------------------------
+
+- name: Create compose file
+  ansible.builtin.template:
+    src: docker-compose.yaml.j2
+    dest: "{{ composition_root }}/docker-compose.yaml"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: "0774"
+
+- name: Create .env file
+  ansible.builtin.template:
+    src: environment_vars.j2
+    dest: "{{ composition_root }}/.environment_vars"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: "0774"
+
+# ----------------------------
+# Specific tasks
+# ----------------------------
+
+- name: Create directories
+  ansible.builtin.file:
+    path: "{{ composition_config }}/{{ dir_item }}"
+    state: directory
+  loop_control:
+    loop_var: dir_item
+  loop:
+    - postgres
+    - data
+    - media
+    - export
+    - consume
+
+- name: Run Configure DNS role
+  ansible.builtin.include_role:
+    name: "network-register-subdomain"
+  vars:
+    configure_dns_subdomains: "{{ composition_paperless_ngx_subdomains }}"
+
+# ----------------------------
+# Start composition
+# ----------------------------
+
+- name: Start Docker Compose project
+  community.docker.docker_compose_v2:
+    project_src: "{{ composition_root }}"
+    state: present
+    build: always
+    remove_orphans: true
+  notify: Restart Traefik

--- a/roles/composition-paperless-ngx/templates/docker-compose.yaml.j2
+++ b/roles/composition-paperless-ngx/templates/docker-compose.yaml.j2
@@ -1,0 +1,89 @@
+name: "{{ composition_name }}"
+services:
+  broker:
+    container_name: paperless_redis
+    image: docker.io/library/redis:7
+    restart: unless-stopped
+    volumes:
+      - "{{ composition_config }}/redis:/data"
+    networks:
+      - "{{ default_docker_network }}"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  db:
+    container_name: paperless_db
+    image: docker.io/library/postgres:16
+    restart: unless-stopped
+    env_file: .environment_vars
+    volumes:
+      - "{{ composition_config }}/postgres:/var/lib/postgresql/data"
+      - /etc/localtime:/etc/localtime:ro
+    networks:
+      - "{{ default_docker_network }}"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U paperless -d paperless"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  gotenberg:
+    container_name: paperless_gotenberg
+    image: docker.io/gotenberg/gotenberg:8
+    restart: unless-stopped
+    command:
+      - "gotenberg"
+      - "--chromium-disable-javascript=true"
+      - "--chromium-allow-list=file:///tmp/.*"
+    networks:
+      - "{{ default_docker_network }}"
+
+  tika:
+    container_name: paperless_tika
+    image: docker.io/apache/tika:latest
+    restart: unless-stopped
+    networks:
+      - "{{ default_docker_network }}"
+
+  webserver:
+    container_name: paperless_webserver
+    image: ghcr.io/paperless-ngx/paperless-ngx:latest
+    restart: unless-stopped
+    env_file: .environment_vars
+    depends_on:
+      db:
+        condition: service_healthy
+      broker:
+        condition: service_healthy
+      gotenberg:
+        condition: service_started
+      tika:
+        condition: service_started
+    volumes:
+      - "{{ composition_config }}/data:/usr/src/paperless/data"
+      - "{{ composition_config }}/media:/usr/src/paperless/media"
+      - "{{ composition_config }}/export:/usr/src/paperless/export"
+      - "{{ composition_config }}/consume:/usr/src/paperless/consume"
+      - /etc/localtime:/etc/localtime:ro
+    networks:
+      - "{{ default_docker_network }}"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.paperless.rule=Host(`paperless.{{ domainname_infra }}`)"
+      - "traefik.http.routers.paperless.tls=true"
+      - "traefik.http.routers.paperless.tls.certresolver=letsencrypt"
+      - "traefik.http.services.paperless.loadbalancer.server.port=8000"
+    healthcheck:
+      test: ["CMD", "curl", "-fs", "-S", "--max-time", "2", "http://localhost:8000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 1m
+
+networks:
+  "{{ default_docker_network }}":
+    external: true

--- a/roles/composition-paperless-ngx/templates/environment_vars.j2
+++ b/roles/composition-paperless-ngx/templates/environment_vars.j2
@@ -1,0 +1,23 @@
+TZ="Europe/Berlin"
+
+# Postgres
+POSTGRES_DB=paperless
+POSTGRES_USER=paperless
+POSTGRES_PASSWORD={{ paperless_ngx_db_password }}
+
+# paperless-ngx
+PAPERLESS_REDIS=redis://broker:6379
+PAPERLESS_DBHOST=db
+PAPERLESS_DBNAME=paperless
+PAPERLESS_DBUSER=paperless
+PAPERLESS_DBPASS={{ paperless_ngx_db_password }}
+PAPERLESS_SECRET_KEY={{ paperless_ngx_secret_key }}
+PAPERLESS_URL=https://paperless.{{ domainname_infra }}
+PAPERLESS_TIME_ZONE=Europe/Berlin
+PAPERLESS_OCR_LANGUAGE=eng
+PAPERLESS_TIKA_ENABLED=1
+PAPERLESS_TIKA_GOTENBERG_ENDPOINT=http://gotenberg:3000
+PAPERLESS_TIKA_ENDPOINT=http://tika:9998
+PAPERLESS_ADMIN_USER={{ paperless_ngx_admin_user }}
+PAPERLESS_ADMIN_PASSWORD={{ paperless_ngx_admin_password }}
+PAPERLESS_ADMIN_MAIL={{ paperless_ngx_admin_mail }}


### PR DESCRIPTION
Deploys paperless-ngx with PostgreSQL, Redis, Gotenberg, and Tika
onto the storage server. Includes vault stub for required secrets.

https://claude.ai/code/session_01Sjq63AmcNpC9xqn5NtaTei