### PR TITLE
feat(infra-named): network-wide ad blocking on bertha via BIND RPZ

### DIFF
--- a/docs/router.md
+++ b/docs/router.md
@@ -34,7 +34,7 @@ Roles run in this order (each builds on the previous):
   static `192.168.1.1`.
 - `network-routing-basic`: IPv4 forwarding, NAT, and the firewall.
 - `infra-dhcpd`: the LAN's DHCP server.
-- `infra-named`: the LAN's authoritative DNS server.
+- `infra-named`: the LAN's authoritative DNS server, and its ad blocker.
 
 ## NAT and forwarding
 
@@ -95,6 +95,34 @@ Legacy devices still searching the previous internal domain
 (`i.affordablepotatoes.com`) resolve via a **DNAME alias** onto the current
 domain (`bind_dname_aliases`), so e.g. `jellyfin.i.affordablepotatoes.com`
 resolves to the current `jellyfin.*` record without touching those devices.
+
+## Ad blocking
+
+Because `infra-dhcpd` hands out bertha as the *only* resolver, blocking here
+cannot be bypassed by a client picking its own DNS server. That is done with
+BIND **Response Policy Zones** rather than a Pi-hole: RPZ is the same "lie about
+ad domains" mechanism, in the resolver already running, so the router keeps its
+no-Docker footprint and the inventory-generated zones above stay untouched.
+
+`bind_rpz_enabled: true` pulls HaGeZi Multi Normal (~181k domains) as a policy
+zone. A daily systemd timer (`bind-rpz-refresh.timer`) re-fetches it, validates
+it with `named-checkzone`, and `rndc reload`s just that zone — never installing
+a list that fails validation, and never restarting named (which would throw away
+the resolver cache). Loading the list costs named about 250 MB of RSS.
+
+A local `rpz.allowlist` policy zone is listed **first**, so an `rpz-passthru`
+entry there beats every blocklist. It always contains the internal domain and
+the DNAME aliases, so no public blocklist can shadow our own names.
+
+**Runbook — a site is broken and you suspect blocking:**
+
+```bash
+# The RPZ log names the exact rule that fired
+grep <domain> /var/log/named/rpz.log
+```
+
+Then add the domain to `bind_rpz_allowlist_extra` in bertha's host_vars and
+re-run the role. See `roles/infra-named/README.md` for the blocklist tiers.
 
 ## IPv6 stance: intentionally IPv4-only
 
@@ -164,4 +192,4 @@ assertion that fails early, listing the offending duplicates.
 - `network-netplan`: netplan rendering (see `roles/network-netplan/README.md`).
 - `network-routing-basic`: forwarding, NAT, and firewall.
 - `infra-dhcpd`: LAN DHCP server.
-- `infra-named`: LAN authoritative / split-horizon DNS.
+- `infra-named`: LAN authoritative / split-horizon DNS, plus RPZ ad blocking.

--- a/inventory/host_vars/router-4gb-bertha/core.yaml
+++ b/inventory/host_vars/router-4gb-bertha/core.yaml
@@ -92,6 +92,22 @@ bind_dname_aliases:
   - i.affordablepotatoes.com
 
 # -------------------------------------------------------------------
+# DNS FILTERING (infra-named RPZ) — network-wide ad/tracker blocking
+# -------------------------------------------------------------------
+# dhcpd hands out bertha as the ONLY resolver, so filtering here cannot be
+# bypassed by a client picking a different DNS server. Role default is `false`;
+# this is the one host where it makes sense.
+bind_rpz_enabled: true
+# HaGeZi Multi Normal: ~181k domains, the balanced tier. See the role README for
+# the other tiers and how to layer the malware/phishing list alongside.
+bind_rpz_zones:
+  - name: rpz.hagezi-multi
+    url: https://raw.githubusercontent.com/hagezi/dns-blocklists/main/rpz/multi.txt
+# Domains a blocklist gets wrong. The internal domain and the DNAME alias above
+# are protected automatically — only add genuine false positives here.
+bind_rpz_allowlist_extra: []
+
+# -------------------------------------------------------------------
 # ANSIBLE
 # -------------------------------------------------------------------
 ansible_host: "{{ host_ipv4 }}"

--- a/roles/infra-named/README.md
+++ b/roles/infra-named/README.md
@@ -21,4 +21,89 @@ named-checkzone DOMAINNAME /etc/bind/zones/db.DOMAINNAME.zone
 named-checkzone 168.192.in-addr.arpa /etc/bind/zones/db.DOMAINNAME.reverse.zone
 ```
 
+## DNS filtering (Response Policy Zones)
+
+Optional Pi-hole-style ad/tracker blocking, done natively in BIND rather than by
+bolting a second resolver onto the network. Off unless `bind_rpz_enabled: true`;
+when off, the rendered config is byte-identical to a build without this feature.
+
+[HaGeZi](https://github.com/hagezi/dns-blocklists) publishes its blocklists as
+ready-made RPZ zone files — `$TTL`, `SOA`, `NS` and `CNAME .` (NXDOMAIN) records
+— so there is no hosts-file conversion step and no generator script to maintain.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `bind_rpz_enabled` | `false` | Master switch |
+| `bind_rpz_zones` | HaGeZi Multi Normal | `name` (zone origin) + `url` per blocklist, in precedence order |
+| `bind_rpz_allowlist_extra` | `[]` | Domains to never block |
+| `bind_rpz_allowlist` | internal domain + DNAME aliases + `_extra` | Full allowlist; override only to drop the protected defaults |
+| `bind_rpz_refresh_schedule` | `daily` | systemd `OnCalendar` for the refresh timer |
+| `bind_rpz_min_bytes` | `100000` | Smallest plausible blocklist; anything less is rejected |
+| `bind_rpz_dir` | `/etc/bind/zones/rpz` | Where policy zones live |
+| `bind_rpz_log_file` | `/var/log/named/rpz.log` | Blocked-query log |
+
+### Blocklist tiers
+
+All at `https://raw.githubusercontent.com/hagezi/dns-blocklists/main/rpz/`:
+
+| File | Domains | Blocking level |
+|------|---------|----------------|
+| `light.txt` | ~42k | Relaxed — least likely to break anything |
+| `multi.txt` | ~181k | Balanced. The default |
+| `pro.txt` | ~216k | More aggressive telemetry blocking |
+| `pro.plus.txt` | ~239k | Aggressive |
+| `ultimate.txt` | ~269k | Maximum |
+| `tif.mini.txt` | — | Malware/phishing threat intel; layer *alongside* a tier, not instead of one |
+
+If `raw.githubusercontent.com` is unreachable, the same paths exist under
+`https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/rpz/`.
+
+Adding a second list is just another entry in `bind_rpz_zones`. Ordering is
+meaningful: zones are consulted in the order listed, and the local allowlist is
+always inserted first.
+
+### Allowlisting a false positive
+
+Add the domain to `bind_rpz_allowlist_extra` in host_vars and re-run the role.
+It is rendered into a local `rpz.allowlist` policy zone as an `rpz-passthru`
+record covering both the domain and everything beneath it, and that zone is
+listed first, so it beats every blocklist. Do not edit the zone file on the
+host — it is regenerated on each run.
+
+To find out *why* something is broken, the RPZ log names the exact rule:
+
+```
+rpz: client 192.168.1.50#41439 (doubleclickbygoogle.com): rpz QNAME NXDOMAIN
+     rewrite doubleclickbygoogle.com/A/IN via doubleclickbygoogle.com.rpz.hagezi-multi
+```
+
+### Refreshing
+
+`bind-rpz-refresh.timer` runs `/usr/local/sbin/bind-rpz-refresh` daily. Per list
+it does a conditional GET (so an unchanged list transfers nothing), rejects an
+implausibly small body, runs `named-checkzone`, and only then installs the file
+and does `rndc reload <zone>` — a reload rather than a restart, so the resolver
+cache survives. **Nothing is installed until it validates**, so a truncated or
+corrupted download leaves the previous good blocklist in place.
+
+> Reloaded rules take up to a minute to bite: named rebuilds the RPZ summary
+> database no more often than `min-update-interval` (60s by default). A domain
+> that is still resolving right after a refresh is almost certainly this, not a
+> failed reload — `rndc zonestatus <zone>` shows whether the zone itself loaded.
+
+The role runs the same script once before templating `named.conf.options`,
+because named refuses to load a policy zone whose file is missing. A refresh
+failure only fails the play while a zone has no file yet; after that a transient
+upstream outage just means a stale list, and the timer is what surfaces it:
+
+```bash
+systemctl status bind-rpz-refresh.service
+journalctl -u bind-rpz-refresh
+```
+
+### Costs
+
+Loading Multi Normal takes named's RSS to roughly 250 MB and adds ~2s to
+startup. Fine on bertha (4 GB); check before enabling on anything smaller.
+
 This is just personal stuff. Not for use by anyone, etc.

--- a/roles/infra-named/defaults/main.yaml
+++ b/roles/infra-named/defaults/main.yaml
@@ -43,3 +43,53 @@ bind_records_nameservers:
 # bind_records_mx:
 # Manually created TXT records
 # bind_records_txt:
+
+# -------------------------------------------------------------------
+# DNS FILTERING — Response Policy Zones (RPZ)
+# -------------------------------------------------------------------
+# Pi-hole-style ad/tracker blocking done natively in BIND. Off by default: this
+# role also serves hosts that are not the LAN's resolver, and filtering is only
+# meaningful where every client's DNS actually lands. Enable in host_vars.
+# When false, no response-policy block is emitted and no timer is installed, so
+# the rendered config is byte-identical to before.
+bind_rpz_enabled: false
+
+# Blocklists to fetch, in the order BIND should consult them. Each needs a
+# `name` (the zone origin — arbitrary, but must be unique and stable, since it
+# is also the `rndc reload` target) and a `url` serving a ready-made RPZ zone.
+# HaGeZi publishes native .rpz files, so nothing needs converting. Tiers:
+#   light.txt     ~42k domains  (relaxed)
+#   multi.txt    ~181k domains  (balanced — the sane default)
+#   pro.txt      ~216k domains  (more aggressive telemetry blocking)
+#   tif.mini.txt          (malware/phishing threat intel, layer alongside)
+# Mirror if raw.githubusercontent is unreachable:
+#   https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/rpz/multi.txt
+bind_rpz_zones:
+  - name: rpz.hagezi-multi
+    url: https://raw.githubusercontent.com/hagezi/dns-blocklists/main/rpz/multi.txt
+
+bind_rpz_dir: /etc/bind/zones/rpz
+bind_rpz_refresh_script: /usr/local/sbin/bind-rpz-refresh
+bind_rpz_service_name: bind-rpz-refresh
+
+# Domains that must NEVER be blocked. Rendered into a local RPZ zone that is
+# listed FIRST in response-policy, so a passthru match wins over any blocklist.
+# The defaults protect our own authoritative names: a public blocklist has no
+# business shadowing the internal zone or the legacy DNAME subtree.
+bind_rpz_allowlist: "{{ [bind_domain] + (bind_dname_aliases | default([])) + (bind_rpz_allowlist_extra | default([])) }}"
+# Set this in host_vars to allowlist a blocklist false positive without having
+# to restate the protected defaults above.
+bind_rpz_allowlist_extra: []
+
+# systemd OnCalendar expression for the refresh timer. Upstream lists change
+# daily; the script does a conditional GET, so a no-op run costs ~nothing.
+bind_rpz_refresh_schedule: daily
+
+# Floor for a plausible blocklist download, in bytes. A proxy error page or a
+# truncated transfer is far smaller than any real list; anything under this is
+# rejected before it can reach named-checkzone.
+bind_rpz_min_bytes: 100000
+
+# Blocked-query log. Separate from the general named log so "why is this site
+# broken?" is one grep away.
+bind_rpz_log_file: /var/log/named/rpz.log

--- a/roles/infra-named/tasks/main.yaml
+++ b/roles/infra-named/tasks/main.yaml
@@ -28,6 +28,105 @@
     group: bind
     mode: "0644"
 
+# --- DNS filtering (RPZ) ----------------------------------------------------
+# These run BEFORE named.conf.options is templated, and that order is
+# load-bearing: named refuses to load a policy zone whose file is missing, so
+# the zones must exist on disk before the config can reference them.
+
+- name: Ensure RPZ zone dir exists
+  become: true
+  ansible.builtin.file:
+    dest: "{{ bind_rpz_dir }}"
+    state: directory
+    owner: root
+    group: bind
+    mode: "0755"
+  when: bind_rpz_enabled
+
+- name: Ensure named log dir exists
+  become: true
+  ansible.builtin.file:
+    dest: "{{ bind_rpz_log_file | dirname }}"
+    state: directory
+    owner: bind
+    group: bind
+    mode: "0755"
+  when: bind_rpz_enabled
+
+- name: Deploy RPZ blocklist refresh script
+  become: true
+  ansible.builtin.template:
+    src: bind-rpz-refresh.sh.j2
+    dest: "{{ bind_rpz_refresh_script }}"
+    owner: root
+    group: root
+    mode: "0755"
+  when: bind_rpz_enabled
+
+- name: Check which RPZ blocklists are already on disk
+  become: true
+  ansible.builtin.stat:
+    path: "{{ bind_rpz_dir }}/db.{{ item.name }}"
+  loop: "{{ bind_rpz_zones }}"
+  loop_control:
+    label: "{{ item.name }}"
+  register: bind_rpz_existing
+  when: bind_rpz_enabled
+
+# Run the script rather than fetching with get_url, so there is a single code
+# path for downloading, validating and installing a policy zone. It is a no-op
+# (conditional GET) once the lists are current, so this is cheap on every run.
+- name: Fetch and validate RPZ blocklists
+  become: true
+  ansible.builtin.command:
+    cmd: "{{ bind_rpz_refresh_script }}"
+  register: bind_rpz_refresh
+  changed_when: "'updated' in bind_rpz_refresh.stdout"
+  # A failed refresh is only fatal while a policy zone has no file yet — named
+  # refuses to load a zone whose file is missing, so the config below must not
+  # reference it. Once a validated copy exists, a transient upstream outage just
+  # means a stale blocklist, which is no reason to fail the whole play. The
+  # systemd timer is what surfaces ongoing refresh failures.
+  failed_when:
+    - bind_rpz_refresh.rc != 0
+    - bind_rpz_existing.results | rejectattr('stat.exists') | list | length > 0
+  when: bind_rpz_enabled
+
+- name: Ensure RPZ allowlist zone exists
+  become: true
+  ansible.builtin.template:
+    src: db.rpz.allowlist
+    dest: "{{ bind_rpz_dir }}/db.rpz.allowlist"
+    owner: root
+    group: bind
+    mode: "0644"
+    validate: named-checkzone -q rpz.allowlist %s
+  when: bind_rpz_enabled
+  notify:
+    - Restart named
+
+- name: Ensure RPZ refresh timer is scheduled
+  become: true
+  ansible.builtin.template:
+    src: "bind-rpz-refresh.{{ item }}.j2"
+    dest: "/etc/systemd/system/{{ bind_rpz_service_name }}.{{ item }}"
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - service
+    - timer
+  when: bind_rpz_enabled
+
+- name: Ensure RPZ refresh timer is enabled
+  become: true
+  ansible.builtin.systemd:
+    name: "{{ bind_rpz_service_name }}.timer"
+    enabled: true
+    state: started
+    daemon_reload: true
+  when: bind_rpz_enabled
+
 - name: Ensure config file exist
   become: true
   ansible.builtin.template:
@@ -37,6 +136,8 @@
     group: bind
     mode: "0644"
     validate: named-checkconf %s
+  notify:
+    - Restart named
 
 # A CNAME is a singleton RR type: two CNAMEs at the same owner name make named
 # reject the ENTIRE zone ("multiple RRs of singleton type"), taking down all

--- a/roles/infra-named/templates/bind-rpz-refresh.service.j2
+++ b/roles/infra-named/templates/bind-rpz-refresh.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Refresh BIND RPZ blocklists
+Documentation=https://github.com/hagezi/dns-blocklists
+After=network-online.target named.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart={{ bind_rpz_refresh_script }}
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=1800
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/infra-named/templates/bind-rpz-refresh.sh.j2
+++ b/roles/infra-named/templates/bind-rpz-refresh.sh.j2
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Refresh BIND Response Policy Zones from upstream blocklists.
+#
+# MANAGED BY ANSIBLE (roles/infra-named) — local edits will be overwritten.
+#
+# Run by {{ bind_rpz_service_name }}.timer ({{ bind_rpz_refresh_schedule }}), and once by the
+# role itself so the zone files exist before named.conf.options references them.
+#
+# The guiding rule: a bad download must never be able to take DNS down. Nothing
+# is installed until named-checkzone has accepted it, and the previous good zone
+# stays in place if anything goes wrong.
+
+set -euo pipefail
+
+ZONE_DIR="{{ bind_rpz_dir }}"
+MIN_BYTES={{ bind_rpz_min_bytes }}
+
+failed=0
+updated=0
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+refresh_zone() {
+  local origin="$1" url="$2"
+  local dest="${ZONE_DIR}/db.${origin}"
+  local etag="${ZONE_DIR}/.${origin}.etag"
+  local tmp="${tmpdir}/${origin}"
+
+  # Conditional GET: these lists are ~10MB and change once a day, so most runs
+  # should transfer nothing at all. --etag-compare on a missing file is a plain
+  # unconditional GET, which is what we want on the very first run.
+  if ! curl --silent --show-error --location --fail \
+       --max-time 300 --retry 3 --retry-delay 5 \
+       --etag-compare "$etag" --etag-save "$etag" \
+       --output "$tmp" "$url"; then
+    echo "ERROR: ${origin}: download failed from ${url}" >&2
+    return 1
+  fi
+
+  # 304 Not Modified leaves an empty body behind: nothing to do.
+  if [[ ! -s "$tmp" ]]; then
+    echo "${origin}: unchanged"
+    return 0
+  fi
+
+  # A proxy error page or a truncated transfer is orders of magnitude smaller
+  # than any real blocklist. Reject it before it can reach named-checkzone.
+  local size
+  size="$(stat -c %s "$tmp")"
+  if (( size < MIN_BYTES )); then
+    echo "ERROR: ${origin}: download is only ${size} bytes (minimum ${MIN_BYTES}), refusing" >&2
+    # Drop the saved ETag so the next run re-fetches instead of getting a 304
+    # against the body we just threw away.
+    rm -f "$etag"
+    return 1
+  fi
+
+  if ! named-checkzone -q "$origin" "$tmp"; then
+    echo "ERROR: ${origin}: named-checkzone rejected the downloaded zone, keeping the existing one" >&2
+    rm -f "$etag"
+    return 1
+  fi
+
+  if [[ -f "$dest" ]] && cmp --silent "$tmp" "$dest"; then
+    echo "${origin}: unchanged"
+    return 0
+  fi
+
+  install -o root -g bind -m 0644 "$tmp" "${dest}.new"
+  mv -f "${dest}.new" "$dest"
+  echo "${origin}: updated (${size} bytes)"
+  updated=1
+
+  # Reload just this zone rather than restarting named — a restart would throw
+  # away the resolver cache every single day. On the role's first run named does
+  # not know the zone yet, so a failure here is expected and not fatal; the
+  # named.conf.options change that follows triggers a full restart.
+  #
+  # The new rules do not take effect the instant this returns: named rebuilds
+  # the RPZ summary database no more often than `min-update-interval` (60s by
+  # default), so expect up to a minute of lag before queries are blocked. That
+  # is a non-issue for a daily refresh, but it looks exactly like a broken
+  # reload if you test immediately.
+  if ! rndc reload "$origin" >/dev/null 2>&1; then
+    echo "${origin}: rndc reload skipped (zone not yet known to named)"
+  fi
+}
+
+mkdir -p "$ZONE_DIR"
+
+{% for item in bind_rpz_zones %}
+refresh_zone "{{ item.name }}" "{{ item.url }}" || failed=1
+{% endfor %}
+
+if (( failed )); then
+  echo "One or more policy zones failed to refresh; existing zones left in place." >&2
+  exit 1
+fi
+
+if (( updated )); then
+  echo "RPZ refresh complete: zones updated"
+else
+  echo "RPZ refresh complete: no changes"
+fi

--- a/roles/infra-named/templates/bind-rpz-refresh.timer.j2
+++ b/roles/infra-named/templates/bind-rpz-refresh.timer.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Refresh BIND RPZ blocklists on a schedule
+Requires={{ bind_rpz_service_name }}.service
+
+[Timer]
+OnCalendar={{ bind_rpz_refresh_schedule }}
+# Spread the fetch out rather than hammering the CDN on the hour, and don't let
+# a reboot-time run collide with named still coming up.
+RandomizedDelaySec=3600
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/infra-named/templates/db.rpz.allowlist
+++ b/roles/infra-named/templates/db.rpz.allowlist
@@ -1,0 +1,31 @@
+#jinja2: lstrip_blocks:True, trim_blocks:True
+; Local RPZ allowlist — the escape hatch for blocklist false positives.
+; Listed FIRST in response-policy, so a match here beats every blocklist.
+;
+; Managed by Ansible (roles/infra-named). To allowlist a domain, add it to
+; `bind_rpz_allowlist_extra` in host_vars and re-run the role — do not edit
+; this file on the host, it will be overwritten.
+;
+; Names are relative to the zone origin, which is how RPZ works: an entry
+; `example.com` here matches a query for `example.com`, and `*.example.com`
+; matches everything beneath it.
+$TTL {{ bind_default_ttl }}
+$ORIGIN rpz.allowlist.
+@ IN SOA {{ bind_records_nameservers[0].name }}.{{ bind_domain }}. admin.{{ domainname_infra }}. (
+{# Serial is derived from the allowlist contents: stable across no-op runs (so #}
+{# the role stays idempotent) and different whenever the list changes. It is    #}
+{# deliberately not monotonic — this zone never transfers (allow-transfer none) #}
+{# and a change here notifies a full `Restart named`, which loads zone files    #}
+{# without comparing serials at all.                                            #}
+  {{ (bind_rpz_allowlist | unique | sort | join(',') | hash('sha1'))[:8] | int(base=16) }} ; Serial
+  604800 ; Refresh
+  86400 ; Retry
+  2419200 ; Expire
+  604800 ; Negative Cache TTL
+)
+  IN NS {{ bind_records_nameservers[0].name }}.{{ bind_domain }}.
+
+{% for domain in bind_rpz_allowlist | unique | sort %}
+{{ domain }} CNAME rpz-passthru.
+*.{{ domain }} CNAME rpz-passthru.
+{% endfor %}

--- a/roles/infra-named/templates/named.conf.options
+++ b/roles/infra-named/templates/named.conf.options
@@ -81,8 +81,65 @@ options {
   # them. Beware! - if the forwarders are down, the NS will not
   # answer non-authoritative queries at all!
   # forward only;
+{% if bind_rpz_enabled %}
+
+  # -----------------------------------------------------------
+  # DNS filtering (Response Policy Zones)
+  # -----------------------------------------------------------
+  # Policy zones are consulted in the order listed and, for matches of the same
+  # trigger type (ours are all QNAME), the first zone listed wins. The local
+  # allowlist MUST therefore come first, so a passthru always beats a blocklist.
+  #
+  # qname-wait-recurse no: answer straight from the policy zone instead of
+  # recursing first only to throw the answer away. The whole point is that we
+  # never contact the ad domain.
+  response-policy {
+    zone "rpz.allowlist" policy passthru;
+{% for item in bind_rpz_zones %}
+    zone "{{ item.name }}";
+{% endfor %}
+  } qname-wait-recurse no;
+{% endif %}
 
 };
+{% if bind_rpz_enabled %}
+
+# -----------------------------------------------------------
+# Response Policy Zones
+# -----------------------------------------------------------
+# Policy data, not published data: clients may be *affected* by these zones but
+# must not be able to query or transfer them.
+#
+# The allowlist is rendered by Ansible from `bind_rpz_allowlist`. The blocklists
+# are fetched, validated and installed by {{ bind_rpz_refresh_script }},
+# never templated — Ansible only guarantees they exist before named sees them.
+
+zone "rpz.allowlist" {
+  type primary;
+  file "{{ bind_rpz_dir }}/db.rpz.allowlist";
+  allow-query { none; };
+  allow-transfer { none; };
+};
+
+{% for item in bind_rpz_zones %}
+zone "{{ item.name }}" {
+  type primary;
+  file "{{ bind_rpz_dir }}/db.{{ item.name }}";
+  allow-query { none; };
+  allow-transfer { none; };
+};
+
+{% endfor %}
+logging {
+  channel rpz_log {
+    file "{{ bind_rpz_log_file }}" versions 3 size 10m;
+    severity info;
+    print-time yes;
+    print-category yes;
+  };
+  category rpz { rpz_log; };
+};
+{% endif %}
 
 zone "{{ bind_domain }}" {
   type primary;


### PR DESCRIPTION
Bertha is the LAN's only resolver (infra-dhcpd deliberately hands out no
secondary), so blocking there cannot be bypassed by a client picking its own
DNS server. Do it with BIND Response Policy Zones rather than adding a
Pi-hole: RPZ is the same mechanism in the resolver already running, so the
router keeps its no-Docker footprint and the inventory-generated forward,
reverse and DNAME zones stay untouched.

HaGeZi publishes its blocklists as ready-made RPZ zone files, so there is no
hosts-file conversion step and no third-party generator to maintain. Default
is Multi Normal (~181k domains); other tiers are one host_var away.

- Off by default (bind_rpz_enabled); with it off the rendered named.conf.options
  is byte-identical to before, verified by diffing both renders.
- A local rpz.allowlist zone is listed first, so an rpz-passthru entry beats
  every blocklist. It always covers the internal domain and the DNAME aliases,
  so no public list can shadow our own names.
- Policy zones get allow-query/allow-transfer none: clients are affected by
  them but cannot query or dump them.
- A daily systemd timer refreshes each list: conditional GET, size floor,
  named-checkzone, atomic install, then rndc reload of just that zone so the
  resolver cache survives. Nothing is installed until it validates, so a bad
  download leaves the previous good list in place.
- The refresh runs once before named.conf.options is templated, because named
  refuses to load a policy zone whose file is missing. After a good copy
  exists, a failed refresh no longer fails the play — the timer surfaces it.
- RPZ hits are logged to /var/log/named/rpz.log, naming the exact rule that
  fired, which is the answer to "why is this site broken?".

Also notifies Restart named on named.conf.options changes. That was missing,
so config changes were written but never applied until something else
restarted named.

Verified against BIND 9.18.39 with the real 10MB list: config and zones pass
named-checkconf/named-checkzone, blocking works for exact and wildcard names,
allowlist passthru wins over the blocklist, policy zones answer REFUSED to
clients, the refresh script survives 404 / truncated / invalid-zone responses
without touching the installed zone, and re-running it is a no-op. Loading the
list costs named ~250MB RSS.