### PR TITLE
feat(tailscale): declare each host's Tailscale IPv4 in inventory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,9 @@ The primary configuration management tool. Structure:
     - `network-netplan`: Netplan-based network configuration for primary interface (supports static IP and DHCP)
     - `network-register-subdomain`: DNS subdomain registration
     - `network-ip-address-forwarding`: IPv4 forwarding via sysctl
+    - `network-tailscale-token`: Exchanges Tailscale OAuth credentials for an API bearer token
+    - `network-tailscale-authkey`: Mints a one-time Tailscale enrolment key
+    - `network-tailscale-address`: Pins a host's Tailscale IPv4 to the inventory's `host_tailscale_ipv4`
   - `infra-*`: Infrastructure resources provisioned via Terraform
 - **`playbooks/`**: Split into `hosts/` (per-host) and `groups/` (per-group), plus `utility/`
   - Each host directory has several playbook files:

--- a/inventory/README.md
+++ b/inventory/README.md
@@ -4,4 +4,20 @@ In many ways this can be considered the core of my home setup, as this is where 
 
 Items in the inventory are defined in [hosts.yaml](hosts.yaml). Each inventory item then has an equivalent file in [host_vars](host_vars/) that defines variables unique to that host.
 
+## Addresses
+
+Each host declares two addresses in its `host_vars`:
+
+* `host_ipv4` — where it lives on the LAN.
+* `host_tailscale_ipv4` — the address it holds on the tailnet.
+
+Neither is a note-to-self: `network-netplan` applies the first,
+[`network-tailscale-address`](../roles/network-tailscale-address/README.md)
+holds the device to the second, and `infra-named` publishes both as DNS records
+under `domainname_infra` (`<host_pfqdn>` and `ts.<host_pfqdn>` respectively).
+
+Tailscale addresses come out of `100.80.0.0/16` and mirror the LAN, so a host on
+`192.168.1.X` takes `100.80.1.X`. Hosts with no LAN presence are allocated
+sequentially from `100.80.2.0/24`.
+
 Hosts can also belong to one of several groups. These groups are defined in the [hosts.yaml](hosts.yaml) file, and, like the hosts, are extended in one of the files found in [groups](group_vars),

--- a/inventory/host_vars/apple-macmini-m4-16gb-malcolm/core.yaml
+++ b/inventory/host_vars/apple-macmini-m4-16gb-malcolm/core.yaml
@@ -19,6 +19,7 @@ host_description: "Mac Mini M4 16GB - used for LLM and MacOS-specific workloads"
 host_primary_interface: "en0"
 host_ipv4: 192.168.1.99
 host_ipv4_subnet: 24
+host_tailscale_ipv4: 100.80.1.99
 host_mac: "1c:f6:4c:3e:51:a5"
 
 # -------------------------------------------------------------------

--- a/inventory/host_vars/minipc-8gb-homebrain/core.yaml
+++ b/inventory/host_vars/minipc-8gb-homebrain/core.yaml
@@ -19,6 +19,7 @@ host_description: "Home automation hub"
 host_ipv4: 192.168.1.130
 host_primary_interface: "enp1s0"
 host_ipv4_subnet: 24
+host_tailscale_ipv4: 100.80.1.130
 host_mac: "f0:d4:e2:f4:30:6f"
 
 # -------------------------------------------------------------------

--- a/inventory/host_vars/minipc-8gb-test-router/core.yaml
+++ b/inventory/host_vars/minipc-8gb-test-router/core.yaml
@@ -19,6 +19,7 @@ host_description: "Testbed for dual-NIC Linux router"
 host_ipv4: 192.168.1.221
 host_primary_interface: "enp1s0"
 host_ipv4_subnet: 24
+host_tailscale_ipv4: 100.80.1.221
 network_netplan_config:
   ethernets:
     enp1s0: # WAN - our normal networ

--- a/inventory/host_vars/raspberry-pi4-2gb-deedee/core.yaml
+++ b/inventory/host_vars/raspberry-pi4-2gb-deedee/core.yaml
@@ -18,6 +18,7 @@ host_description: "Runs infrastructure tasks"
 # -------------------------------------------------------------------
 host_ipv4: 192.168.1.2
 host_ipv4_subnet: 24
+host_tailscale_ipv4: 100.80.1.2
 host_primary_interface: "eth0"
 host_mac: "e4:5f:01:7e:4a:4e"
 

--- a/inventory/host_vars/raspberry-pi4-2gb-pikvm/core.yaml
+++ b/inventory/host_vars/raspberry-pi4-2gb-pikvm/core.yaml
@@ -19,6 +19,7 @@ host_description: "KVM over IP device"
 host_ipv4: 192.168.1.111
 host_primary_interface: "enp3s0"
 host_ipv4_subnet: 24
+host_tailscale_ipv4: 100.80.1.111
 
 
 # -------------------------------------------------------------------

--- a/inventory/host_vars/raspberry-pi4-4gb-albion/core.yaml
+++ b/inventory/host_vars/raspberry-pi4-4gb-albion/core.yaml
@@ -24,6 +24,7 @@ host_description: "Remote node in London"
 # Docs: roles/network-netplan/README.md
 # -------------------------------------------------------------------
 host_primary_interface: "eth0"
+host_tailscale_ipv4: 100.80.2.2
 tailscale_exit_node: true
 
 # -------------------------------------------------------------------

--- a/inventory/host_vars/raspberry-pi4-4gb-randolph/core.yaml
+++ b/inventory/host_vars/raspberry-pi4-4gb-randolph/core.yaml
@@ -18,6 +18,7 @@ host_description: "Runs infrastructure tasks"
 # -------------------------------------------------------------------
 host_ipv4: 192.168.1.3
 host_ipv4_subnet: 24
+host_tailscale_ipv4: 100.80.1.3
 host_primary_interface: "eth0"
 host_mac: "dc:a6:32:71:1a:37"
 

--- a/inventory/host_vars/raspberry-pi4-8gb-norman/core.yaml
+++ b/inventory/host_vars/raspberry-pi4-8gb-norman/core.yaml
@@ -18,6 +18,7 @@ host_description: "Runs infrastructure tasks"
 # -------------------------------------------------------------------
 host_ipv4: 192.168.1.4
 host_ipv4_subnet: 24
+host_tailscale_ipv4: 100.80.1.4
 host_primary_interface: "eth0"
 host_mac: "e4:5f:01:34:5f:0e"
 

--- a/inventory/host_vars/raspberry-pi5-4gb-belinda/core.yaml
+++ b/inventory/host_vars/raspberry-pi5-4gb-belinda/core.yaml
@@ -19,6 +19,7 @@ host_description: "Raspberry Pi 5 backup server"
 host_ipv4: 192.168.1.117
 host_primary_interface: "eth0"
 host_ipv4_subnet: 24
+host_tailscale_ipv4: 100.80.1.117
 tailscale_exit_node: false
 
 # -------------------------------------------------------------------

--- a/inventory/host_vars/router-4gb-bertha/core.yaml
+++ b/inventory/host_vars/router-4gb-bertha/core.yaml
@@ -19,6 +19,7 @@ host_description: "Primary home dual-NIC Linux router"
 host_ipv4: 192.168.1.1 # bertha's LAN address (on enp1s0)
 host_mac: "1c:61:b4:6d:6f:cd" # enp1s0 (LAN) NIC
 host_ipv4_subnet: 24
+host_tailscale_ipv4: 100.80.1.1
 # The WAN (enp2s0) is the netplan "primary" and runs DHCP off the Fritz!Box.
 # Making the WAN the DHCP primary is deliberate: static mode would have the role
 # emit `default via {{ network_netplan_gateway }}` (192.168.1.1) — a default

--- a/inventory/host_vars/server-64gb-storage/core.yaml
+++ b/inventory/host_vars/server-64gb-storage/core.yaml
@@ -19,6 +19,7 @@ host_fqdn: "{{ host_pfqdn }}.{{ domainname_infra }}"
 host_ipv4: 192.168.1.116
 host_primary_interface: "enp3s0"
 host_ipv4_subnet: 24
+host_tailscale_ipv4: 100.80.1.116
 host_mac: "34:60:f9:bb:3d:16"
 
 # -------------------------------------------------------------------

--- a/inventory/host_vars/server-8gb-backups/core.yaml
+++ b/inventory/host_vars/server-8gb-backups/core.yaml
@@ -18,6 +18,7 @@ host_description: "Dedicated backup server (being sunsetted)"
 # -------------------------------------------------------------------
 host_ipv4: 192.168.1.118
 host_ipv4_subnet: 24
+host_tailscale_ipv4: 100.80.1.118
 host_primary_interface: "enp3s0"
 
 # -------------------------------------------------------------------

--- a/inventory/host_vars/vps-hetzner-public01/core.yaml
+++ b/inventory/host_vars/vps-hetzner-public01/core.yaml
@@ -22,6 +22,7 @@ network_netplan_mode: dhcp
 host_ipv4_extra:
   - "{{ hetzner_floating_ip }}/32" # Assign permanent floating IP to this server
 network_netplan_nameservers: ["185.12.64.1", "185.12.64.2"]
+host_tailscale_ipv4: 100.80.2.1
 
 # -------------------------------------------------------------------
 # ANSIBLE

--- a/roles/bootstrap-ubuntu-server/tasks/main.yaml
+++ b/roles/bootstrap-ubuntu-server/tasks/main.yaml
@@ -210,6 +210,11 @@
     tailscale_up_skip: "{{ tailscale_connected }}"
   when: tailscale_exit_node is defined and tailscale_exit_node is true
 
+# Must follow enrolment: a device only has an address to correct once it exists.
+- name: Tailscale - pin the inventory address
+  ansible.builtin.include_role:
+    name: network-tailscale-address
+
 - name: Git
   ansible.builtin.include_role:
     name: system-git

--- a/roles/composition-reverseproxy/templates/providers/gotosocial.yaml
+++ b/roles/composition-reverseproxy/templates/providers/gotosocial.yaml
@@ -38,4 +38,7 @@ http:
       loadBalancer:
         passHostHeader: true
         servers:
-          - url: "http://100.106.129.23:8085"
+          # composition-gotosocial runs on storage and publishes 8085. Reached
+          # over the tailnet, by inventory fact rather than a literal 100.x, so
+          # a re-addressed device does not silently break the public site.
+          - url: "http://{{ hostvars['server-64gb-storage']['host_tailscale_ipv4'] }}:8085"

--- a/roles/composition-reverseproxy/templates/providers/personalsite.yaml
+++ b/roles/composition-reverseproxy/templates/providers/personalsite.yaml
@@ -48,4 +48,6 @@ http:
       loadBalancer:
         passHostHeader: true
         servers:
-          - url: "http://100.106.129.23:8085"
+          # Reached over the tailnet, by inventory fact rather than a literal
+          # 100.x, so a re-addressed device does not silently break the site.
+          - url: "http://{{ hostvars['server-64gb-storage']['host_tailscale_ipv4'] }}:8085"

--- a/roles/infra-named/README.md
+++ b/roles/infra-named/README.md
@@ -8,6 +8,7 @@ This role will:
 * Gather info about machines in the Ansible inventory.
 * Assign inventory FQDNs to inventory IP addresses.
 * Discover application cnames and map them to inventory FQDNs.
+* Publish each host's Tailscale address under a `ts.` name.
 * Generate zone files (normal and reverse).
 
 This setup should also allow an external DHCP server to make changes via [DDNS](https://en.wikipedia.org/wiki/Dynamic_DNS).
@@ -20,6 +21,32 @@ named-checkzone DOMAINNAME /etc/bind/zones/db.DOMAINNAME.zone
 # Check reverse zone file
 named-checkzone 168.192.in-addr.arpa /etc/bind/zones/db.DOMAINNAME.reverse.zone
 ```
+
+## Tailscale addresses
+
+Every host declares its Tailscale address as `host_tailscale_ipv4` in its
+`host_vars` (the [`network-tailscale-address`](../network-tailscale-address/README.md)
+role is what holds the device to it). This role publishes those alongside the
+LAN A records, so each host ends up with a name for both paths to it:
+
+```text
+server-64gb-storage.kberg.ber                IN  A  192.168.1.116
+ts.server-64gb-storage.kberg.ber             IN  A  100.80.1.116
+```
+
+That is the addressable form of "everything is accessed via Tailscale": a
+composition on one host can reach a service on another over the tailnet by name,
+rather than by a hardcoded `100.x` that changes the next time a device is
+re-enrolled.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `bind_tailscale_records_enabled` | `true` | Emit the `ts.` A records at all |
+| `bind_tailscale_record_prefix` | `ts` | Label prefixed to `host_pfqdn` |
+
+Hosts without `host_tailscale_ipv4` are skipped. No PTR records are generated —
+Tailscale addresses reverse under `100.in-addr.arpa`, which this role does not
+serve, and MagicDNS already covers it.
 
 ## DNS filtering (Response Policy Zones)
 

--- a/roles/infra-named/defaults/main.yaml
+++ b/roles/infra-named/defaults/main.yaml
@@ -11,6 +11,21 @@ bind_iprange_segment: 192.168
 bind_iprange_reversed: "{{ bind_iprange_segment | string | split('.') | reverse | join('.') }}"
 bind_ansible_group: infra
 bind_unmanaged_group: unmanaged
+
+# -------------------------------------------------------------------
+# TAILSCALE RECORDS
+# -------------------------------------------------------------------
+# Publish each managed host's Tailscale address (`host_tailscale_ipv4` in
+# host_vars, held there by the network-tailscale-address role) as
+# `<prefix>.<host_pfqdn>.<bind_domain>`, alongside the LAN A record. That gives
+# every host a name for each path to it: the bare pfqdn over the LAN, the `ts.`
+# name over the tailnet — useful from a host that has no LAN route, and stable
+# in a way a raw 100.x address in a config file is not.
+# Hosts with no `host_tailscale_ipv4` are skipped.
+# No PTRs are generated: Tailscale addresses reverse under 100.in-addr.arpa,
+# which this role does not serve — MagicDNS already handles that.
+bind_tailscale_records_enabled: true
+bind_tailscale_record_prefix: ts
 # Define ACL groups for using this DNS server
 bind_acl_groups:
   - name: LAN

--- a/roles/infra-named/templates/db.zone
+++ b/roles/infra-named/templates/db.zone
@@ -50,6 +50,17 @@ $ORIGIN    {{ bind_domain }}.
   {% endif %}
 {% endfor %}
 
+; A records - Tailscale addresses from Ansible inventory (managed hosts)
+{% if bind_tailscale_records_enabled %}
+  {% for host in groups[bind_ansible_group] %}
+    {% if (hostvars[host].host_pfqdn is defined) and (hostvars[host].host_tailscale_ipv4 is defined) %}
+      {% if hostvars[host].host_tailscale_ipv4 %}
+        {{- '%-40s' | format(bind_tailscale_record_prefix + '.' + hostvars[host].host_pfqdn) }} IN      A         {{ hostvars[host].host_tailscale_ipv4 }}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
 ; cnames - from Ansible inventory
 {% for host in groups[bind_ansible_group] %}
   {% if hostvars[host].cnames is defined %}

--- a/roles/network-tailscale-address/README.md
+++ b/roles/network-tailscale-address/README.md
@@ -1,0 +1,74 @@
+# network-tailscale-address
+
+Makes a host's Tailscale IPv4 address a declared property of the inventory
+rather than whatever Tailscale happened to hand out at enrolment. Every host
+sets `host_tailscale_ipv4` in its `host_vars`; this role holds the device to it.
+
+Once addresses are stable they can be referenced like any other inventory fact —
+`infra-named` publishes them as `ts.<host_pfqdn>.{{ domainname_infra }}` A
+records, and compositions can point at
+`hostvars['<host>']['host_tailscale_ipv4']` instead of a hardcoded `100.x`.
+
+## What it does
+
+1. Skips entirely unless `host_tailscale_ipv4` is set and
+   `tailscale_address_enforce` is true.
+2. Asserts the declared address sits inside Tailscale's `100.64.0.0/10` range.
+3. Reads the host's current address with `tailscale ip -4`. An unenrolled host
+   has none, so there is nothing to re-address — the role stops there.
+4. If the current address already matches, stops. This is the normal path, so
+   repeat runs cost one local command and no API calls.
+5. Otherwise looks the device up in the tailnet **by its current address** (not
+   by hostname, which Tailscale may have suffixed) and `POST`s the new address
+   to `/api/v2/device/{deviceID}/ip`.
+6. Waits for `tailscaled` to start answering with the new address.
+
+## Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `host_tailscale_ipv4` | *(unset)* | The address this host should hold. Set per host in `host_vars`. Unset = role does nothing |
+| `tailscale_address_enforce` | `true` | Master switch |
+| `tailscale_api_base` | `https://api.tailscale.com/api/v2` | API root |
+| `tailscale_address_verify_retries` | `12` | Attempts to wait for the new address |
+| `tailscale_address_verify_delay` | `5` | Seconds between attempts |
+
+## Where it runs
+
+Included by the roles that enrol a host onto the tailnet, immediately after
+enrolment — `bootstrap-ubuntu-server` and `system-pikvm`. Tailscale on
+`apple-macmini-m4-16gb-malcolm` is installed by hand (a Homebrew cask, not an
+Ansible role), so its `host_tailscale_ipv4` is declarative only: `infra-named`
+publishes it, but nothing enforces it. Set that one in the Tailscale admin
+console to match, or the DNS record will point somewhere wrong.
+
+## Prerequisites
+
+The OAuth client behind `network-tailscale-token` needs **write access to the
+`devices:core` scope**, which is separate from the `auth_keys` scope used for
+enrolment. Without it the address call fails with `403`. Add it in Tailscale
+Admin Console → Settings → OAuth clients.
+
+## Reassignment is disruptive
+
+Changing a device's Tailscale address breaks every existing connection to it —
+that is Tailscale's behaviour, not this role's. Two consequences worth knowing
+before the first run:
+
+* **A host reached over the tailnet loses its Ansible connection mid-play.**
+  `ansible_host` for most hosts here is a LAN address, so they are unaffected,
+  but anything whose `ansible_host` is a MagicDNS name (e.g.
+  `raspberry-pi4-4gb-albion`) will drop and needs the playbook re-running once
+  MagicDNS has caught up.
+* **Clients cache the old address.** Flush DNS on anything that was talking to
+  the host (`scripts/flush-dns.sh`).
+
+Because step 4 short-circuits, this only happens on the run that actually
+changes an address.
+
+## Addressing scheme
+
+Addresses are allocated out of `100.80.0.0/16`, mirroring the LAN so they are
+memorable: a host on `192.168.1.X` takes `100.80.1.X`. Hosts with no LAN
+presence (the Hetzner VPS, remote nodes) are allocated sequentially from
+`100.80.2.0/24`.

--- a/roles/network-tailscale-address/defaults/main.yaml
+++ b/roles/network-tailscale-address/defaults/main.yaml
@@ -1,0 +1,15 @@
+# code: language=ansible
+
+# Kept alongside network-tailscale-token's own default: `include_role` does not
+# expose an included role's defaults to the including role, so each role that
+# builds an API URL needs its own copy.
+tailscale_api_base: https://api.tailscale.com/api/v2
+
+# Master switch. When false the role is a no-op, which is the escape hatch for a
+# host that must keep whatever address Tailscale handed it.
+tailscale_address_enforce: true
+
+# After a reassignment, how long to wait for tailscaled to start answering with
+# the new address before failing.
+tailscale_address_verify_retries: 12
+tailscale_address_verify_delay: 5

--- a/roles/network-tailscale-address/meta/main.yaml
+++ b/roles/network-tailscale-address/meta/main.yaml
@@ -1,0 +1,5 @@
+galaxy_info:
+  role_name: network-tailscale-address
+  description: Pins a host's Tailscale IPv4 address to the value declared in inventory
+  min_ansible_version: "2.14"
+dependencies: []

--- a/roles/network-tailscale-address/tasks/main.yaml
+++ b/roles/network-tailscale-address/tasks/main.yaml
@@ -1,0 +1,118 @@
+# code: language=ansible
+
+- name: Pin the Tailscale address declared in inventory
+  when:
+    - tailscale_address_enforce | bool
+    - host_tailscale_ipv4 is defined
+    - host_tailscale_ipv4 | default('', true) | length > 0
+  block:
+
+    # Catch a typo here rather than as an opaque 400 from the API. Tailscale
+    # only hands out addresses from the CGNAT block 100.64.0.0/10.
+    - name: Assert the declared address is inside Tailscale's CGNAT range
+      ansible.builtin.assert:
+        that:
+          - host_tailscale_ipv4 is match('^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.')
+        fail_msg: >-
+          host_tailscale_ipv4 for {{ inventory_hostname }} is
+          '{{ host_tailscale_ipv4 }}', which is outside 100.64.0.0/10.
+          Tailscale will not accept it.
+        success_msg: "{{ host_tailscale_ipv4 }} is a usable Tailscale address."
+        quiet: true
+
+    - name: Read the address Tailscale currently has for this host
+      ansible.builtin.command:
+        cmd: tailscale ip -4
+      register: tailscale_current_ipv4_raw
+      changed_when: false
+      failed_when: false
+
+    - name: Set current Tailscale address fact
+      ansible.builtin.set_fact:
+        tailscale_current_ipv4: >-
+          {{ (tailscale_current_ipv4_raw.stdout_lines | default([]) | first | default('')) | trim }}
+
+    # Nothing to do on a host that is not enrolled (the address is assigned at
+    # enrolment, so there is no device to re-address yet) or already correct.
+    - name: Move the device onto its inventory address
+      when:
+        - tailscale_current_ipv4 | length > 0
+        - tailscale_current_ipv4 != host_tailscale_ipv4
+      block:
+
+        - name: Obtain a Tailscale API token
+          ansible.builtin.include_role:
+            name: network-tailscale-token
+
+        # Matching on the address the host itself reports, rather than on
+        # hostname, avoids picking the wrong device when a name has been reused
+        # or when Tailscale has suffixed it (`storage-1`).
+        - name: List the devices in the tailnet
+          ansible.builtin.uri:
+            url: "{{ tailscale_api_base }}/tailnet/-/devices"
+            method: GET
+            headers:
+              Authorization: "Bearer {{ tailscale_api_token }}"
+            status_code: 200
+          register: tailscale_devices_response
+          no_log: true
+
+        - name: Identify this host's device
+          ansible.builtin.set_fact:
+            tailscale_device_id: >-
+              {{ tailscale_devices_response.json.devices
+                 | selectattr('addresses', 'contains', tailscale_current_ipv4)
+                 | map(attribute='id') | first | default('') }}
+
+        - name: Assert the device was found
+          ansible.builtin.assert:
+            that:
+              - tailscale_device_id | length > 0
+            fail_msg: >-
+              No device in the tailnet holds {{ tailscale_current_ipv4 }}, so
+              {{ inventory_hostname }} cannot be re-addressed. The OAuth client
+              may be scoped to a different tailnet.
+            quiet: true
+
+        # Reassigning drops every existing connection to this machine, including
+        # this Ansible connection if it runs over the tailnet.
+        #
+        # no_log keeps the bearer token out of the failure output, so the status
+        # is checked separately below rather than by `status_code` — otherwise a
+        # rejected address fails with nothing to go on.
+        - name: Set the device's Tailscale IPv4 address
+          ansible.builtin.uri:
+            url: "{{ tailscale_api_base }}/device/{{ tailscale_device_id }}/ip"
+            method: POST
+            headers:
+              Authorization: "Bearer {{ tailscale_api_token }}"
+            body_format: json
+            body:
+              ipv4: "{{ host_tailscale_ipv4 }}"
+            status_code: [200, 204]
+          register: tailscale_address_set
+          changed_when: tailscale_address_set.status | default(0) in [200, 204]
+          failed_when: false
+          no_log: true
+
+        - name: Assert Tailscale accepted the address
+          ansible.builtin.assert:
+            that:
+              - tailscale_address_set.status | default(0) in [200, 204]
+            fail_msg: >-
+              Tailscale refused {{ host_tailscale_ipv4 }} for
+              {{ inventory_hostname }} (HTTP
+              {{ tailscale_address_set.status | default('no response') }}).
+              403 means the OAuth client lacks write access to the devices:core
+              scope; another 4xx usually means the address is already held by a
+              different device.
+            quiet: true
+
+        - name: Wait for tailscaled to pick up the new address
+          ansible.builtin.command:
+            cmd: tailscale ip -4
+          register: tailscale_address_verify
+          changed_when: false
+          until: host_tailscale_ipv4 in tailscale_address_verify.stdout_lines
+          retries: "{{ tailscale_address_verify_retries | int }}"
+          delay: "{{ tailscale_address_verify_delay | int }}"

--- a/roles/network-tailscale-authkey/README.md
+++ b/roles/network-tailscale-authkey/README.md
@@ -1,5 +1,5 @@
 # network-tailscale-authkey
 
-Generates a short-lived Tailscale one-time auth key and exposes it as the `tailscale_authkey` Ansible fact for use by subsequent roles in the same play. Uses OAuth client credentials (`tailscale_oauth_client_id` / `tailscale_oauth_client_secret`) to obtain a bearer token, then calls the Tailscale keys API to issue a pre-authorised, non-reusable key tagged with `tailscale_node_tags`.
+Generates a short-lived Tailscale one-time auth key and exposes it as the `tailscale_authkey` Ansible fact for use by subsequent roles in the same play. Delegates the OAuth credential exchange to [`network-tailscale-token`](../network-tailscale-token/README.md), then calls the Tailscale keys API to issue a pre-authorised, non-reusable key tagged with `tailscale_node_tags`.
 
 The key expires after `tailscale_authkey_expiry_seconds` (default `300`). All API calls are `no_log`.

--- a/roles/network-tailscale-authkey/defaults/main.yaml
+++ b/roles/network-tailscale-authkey/defaults/main.yaml
@@ -1,3 +1,8 @@
 # code: language=ansible
 
+# Kept alongside network-tailscale-token's own default: `include_role` does not
+# expose an included role's defaults to the including role, so each role that
+# builds an API URL needs its own copy.
+tailscale_api_base: https://api.tailscale.com/api/v2
+
 tailscale_authkey_expiry_seconds: 300

--- a/roles/network-tailscale-authkey/tasks/main.yaml
+++ b/roles/network-tailscale-authkey/tasks/main.yaml
@@ -1,24 +1,15 @@
 # code: language=ansible
 
-- name: Exchange OAuth credentials for Bearer token
-  ansible.builtin.uri:
-    url: https://api.tailscale.com/api/v2/oauth/token
-    method: POST
-    body_format: form-urlencoded
-    body:
-      grant_type: client_credentials
-      client_id: "{{ tailscale_oauth_client_id }}"
-      client_secret: "{{ tailscale_oauth_client_secret }}"
-    status_code: 200
-  register: tailscale_oauth_token_response
-  no_log: true
+- name: Obtain a Tailscale API token
+  ansible.builtin.include_role:
+    name: network-tailscale-token
 
 - name: Generate one-time Tailscale auth key
   ansible.builtin.uri:
-    url: https://api.tailscale.com/api/v2/tailnet/-/keys
+    url: "{{ tailscale_api_base }}/tailnet/-/keys"
     method: POST
     headers:
-      Authorization: "Bearer {{ tailscale_oauth_token_response.json.access_token }}"
+      Authorization: "Bearer {{ tailscale_api_token }}"
     body_format: json
     body:
       capabilities:

--- a/roles/network-tailscale-token/README.md
+++ b/roles/network-tailscale-token/README.md
@@ -1,0 +1,28 @@
+# network-tailscale-token
+
+Exchanges the Tailscale OAuth client credentials (`tailscale_oauth_client_id` /
+`tailscale_oauth_client_secret`, both mapped from vault in
+`inventory/group_vars/infra/core.yaml`) for a short-lived API bearer token, and
+exposes it as the `tailscale_api_token` fact.
+
+Every role in this repo that talks to the Tailscale API goes through here rather
+than repeating the OAuth dance:
+
+* `network-tailscale-authkey` — mints a one-time enrolment key.
+* `network-tailscale-address` — pins a device's Tailscale IPv4 address.
+
+Because the token is a host fact, including this role a second time in the same
+play is a no-op — the credential exchange only happens once.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `tailscale_api_base` | `https://api.tailscale.com/api/v2` | API root |
+
+Both API calls are `no_log`.
+
+## OAuth scopes
+
+The OAuth client needs a scope per operation it is used for. `auth_keys` covers
+key generation; **setting a device's address additionally needs `devices:core`
+with write access** (Tailscale Admin Console → Settings → OAuth clients). A
+client missing the scope fails the API call with `403`.

--- a/roles/network-tailscale-token/defaults/main.yaml
+++ b/roles/network-tailscale-token/defaults/main.yaml
@@ -1,0 +1,3 @@
+# code: language=ansible
+
+tailscale_api_base: https://api.tailscale.com/api/v2

--- a/roles/network-tailscale-token/meta/main.yaml
+++ b/roles/network-tailscale-token/meta/main.yaml
@@ -1,0 +1,5 @@
+galaxy_info:
+  role_name: network-tailscale-token
+  description: Exchanges Tailscale OAuth client credentials for a short-lived API bearer token
+  min_ansible_version: "2.14"
+dependencies: []

--- a/roles/network-tailscale-token/tasks/main.yaml
+++ b/roles/network-tailscale-token/tasks/main.yaml
@@ -1,0 +1,25 @@
+# code: language=ansible
+
+# The token is a host fact, so a play that touches the Tailscale API more than
+# once (generate an auth key, then set the device address) exchanges credentials
+# only on the first include.
+
+- name: Exchange OAuth credentials for Bearer token
+  ansible.builtin.uri:
+    url: "{{ tailscale_api_base }}/oauth/token"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      grant_type: client_credentials
+      client_id: "{{ tailscale_oauth_client_id }}"
+      client_secret: "{{ tailscale_oauth_client_secret }}"
+    status_code: 200
+  register: tailscale_oauth_token_response
+  no_log: true
+  when: tailscale_api_token is not defined
+
+- name: Set tailscale_api_token fact
+  ansible.builtin.set_fact:
+    tailscale_api_token: "{{ tailscale_oauth_token_response.json.access_token }}"
+  no_log: true
+  when: tailscale_api_token is not defined

--- a/roles/system-pikvm/tasks/main.yaml
+++ b/roles/system-pikvm/tasks/main.yaml
@@ -89,6 +89,11 @@
   no_log: true
   when: not tailscale_connected and tailscaleup_result.rc != 0
 
+# Must follow enrolment: a device only has an address to correct once it exists.
+- name: Ensure the Tailnet address matches inventory
+  ansible.builtin.include_role:
+    name: network-tailscale-address
+
 - name: Ensure packages are updated
   ansible.builtin.command:
     cmd: pikvm-update --no-reboot


### PR DESCRIPTION
Tailscale addresses were whatever the tailnet handed out at enrolment:
not recorded anywhere, not stable across re-enrolment, and consequently
unusable as infrastructure data. The one place that needed a tailnet
address (traefik's gotosocial/personalsite backends) had 100.106.129.23
hardcoded into a template.

Every host now declares `host_tailscale_ipv4` in its host_vars, and
that declaration is authoritative in both directions:

- `network-tailscale-address` (new) holds the device to it, via the
  Tailscale API's `POST /device/{id}/ip`. Included by the two roles that
  enrol a host (`bootstrap-ubuntu-server`, `system-pikvm`) immediately
  after enrolment. It matches the device by the address the host itself
  reports rather than by hostname, and short-circuits when the address is
  already correct, so a normal run makes no API calls at all.
- `infra-named` publishes them as `ts.<host_pfqdn>` A records alongside
  the existing LAN records, so each host has a name for both paths to it.
  No PTRs: Tailscale reverses under 100.in-addr.arpa, which this role
  does not serve.

`network-tailscale-token` (new) carries the OAuth exchange that
`network-tailscale-authkey` did inline, so both API-using roles share one
credential exchange per play instead of repeating it.

Addresses mirror the LAN to stay memorable: 192.168.1.X becomes
100.80.1.X, with 100.80.2.0/24 for hosts that have no LAN presence.

The traefik backends now resolve through the inventory fact, so the
public site survives storage being re-addressed.

Note: setting a device address needs write access to the OAuth client's
devices:core scope, which is separate from the auth_keys scope used for
enrolment.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017M8SZH83dSoWQLsbFthu82