### PR TITLE
feat(composition-chives): support new profile editor env vars

### DIFF
--- a/roles/composition-chives/defaults/main.yaml
+++ b/roles/composition-chives/defaults/main.yaml
@@ -10,6 +10,10 @@ composition_chives_idle_checkin_hours: 0
 composition_chives_telegram_token: ""
 composition_chives_telegram_chat_id: ""
 
+# Profile markdown editor at /editor is optional — leave blank to disable
+composition_chives_editor_username: ""
+composition_chives_editor_password: ""
+
 # Gateway MCP server URL (Malcolm runs the HTTP gateway at port 4000)
 composition_chives_mcps: []
   # - url: "http://mcp-searxng:3000/mcp"

--- a/roles/composition-chives/templates/environment_vars.j2
+++ b/roles/composition-chives/templates/environment_vars.j2
@@ -9,6 +9,11 @@ CHIVES_TELEGRAM__BOT_TOKEN={{ composition_chives_telegram_token }}
 CHIVES_TELEGRAM__ALLOWED_CHAT_IDS=[{{ composition_chives_telegram_chat_id }}]
 {% endif %}
 
+{% if composition_chives_editor_username %}
+CHIVES_EDITOR__USERNAME={{ composition_chives_editor_username }}
+CHIVES_EDITOR__PASSWORD={{ composition_chives_editor_password }}
+{% endif %}
+
 CHIVES_IMAP__HOST=imap.{{ vault_mailprovider_domain }}
 CHIVES_IMAP__PORT=993
 CHIVES_IMAP__USERNAME={{ vault_mailprovider_user }}


### PR DESCRIPTION
Latest chives adds a basic-auth-protected markdown editor at /editor,
gated by CHIVES_EDITOR__USERNAME/CHIVES_EDITOR__PASSWORD. Wire these
through as optional role vars, following the same pattern as the
existing optional Telegram config — left blank, the editor stays
disabled as it does upstream.