### PR TITLE
public01: dual-mode wildcard cert + scoped ACME for public domains

### DIFF
--- a/inventory/group_vars/all.yaml
+++ b/inventory/group_vars/all.yaml
@@ -54,5 +54,18 @@ vault_domain_test: !vault |
 domainname_infra: "{{ vault_domainname_ew }}"
 domainname_personal: "{{ vault_domainname_aw }}"
 
+# Host-level TLS posture. Read by every composition that emits a Traefik
+# certresolver label, not just composition-reverseproxy - role defaults are
+# role-scoped, so these have to live at inventory level to be in scope for all
+# of them. Override per host; see #276.
+#   use_letsencrypt - the letsencrypt ACME resolver exists in traefik.yaml.
+#   wildcard_cert   - the internal *.ewwww.eu wildcard is mounted and set as
+#                     Traefik's default certificate, so internal routers no
+#                     longer need ACME at all.
+# Both true at once is the public01 case: ACME kept alive for genuinely public
+# names the internal wildcard can never cover, wildcard used for everything else.
+reverseproxy_use_letsencrypt: true
+reverseproxy_wildcard_cert: false
+
 # vault_vagrant_public_key:
 # vault_vagrant_private_key:

--- a/inventory/host_vars/vps-hetzner-public01/core.yaml
+++ b/inventory/host_vars/vps-hetzner-public01/core.yaml
@@ -76,9 +76,23 @@ zfs:
 # -------------------------------------------------------------------
 # SITES
 # -------------------------------------------------------------------
+# REVERSEPROXY (#276 - dual mode: wildcard default + scoped ACME)
+#
+# The one host in the estate that needs both mechanisms at once. The
+# letsencrypt resolver stays alive here, but only for the genuinely public
+# names that the internal *.ewwww.eu wildcard can never cover:
+#   - gts.awfulwoman.com          (gotosocial file provider, below)
+#   - awfulwoman.com + the two old redirect domains
+#                                 (composition-awfulwoman's "beta" router)
+# Every internal name on this host now takes the wildcard as Traefik's default
+# certificate instead. No internal router references the resolver: the
+# certresolver labels are guarded on reverseproxy_wildcard_cert estate-wide.
+reverseproxy_use_letsencrypt: true
+reverseproxy_wildcard_cert: true
 
 traefik_providers:
   - gotosocial
+  - wildcard-cert
 
 # -------------------------------------------------------------------
 # ZFS POLICY

--- a/playbooks/hosts/vps-hetzner-public01/core.yaml
+++ b/playbooks/hosts/vps-hetzner-public01/core.yaml
@@ -16,6 +16,10 @@
     tags: [system, zfs, system-zfs-policy]
   - role: client-nfs
     tags: [client, client-nfs]
+  # Before system-compositions: the wildcard bundle has to be on disk before
+  # Traefik starts and mounts it.
+  - role: client-cert-distribution
+    tags: [infra, client-cert-distribution]
   - role: system-compositions
     tags: [composition, zfs]
   - role: system-promtail

--- a/roles/composition-1password-connect/templates/docker-compose.yaml.j2
+++ b/roles/composition-1password-connect/templates/docker-compose.yaml.j2
@@ -13,7 +13,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.op-connect.rule=Host(`{{ composition_dns_subdomains[0] }}.{{ domainname_infra }}`)"
       - "traefik.http.routers.op-connect.tls=true"
-{% if reverseproxy_use_letsencrypt %}
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.op-connect.tls.certresolver=letsencrypt"
 {% endif %}
       - "traefik.http.services.op-connect.loadbalancer.server.port=8080"

--- a/roles/composition-audiobookshelf/templates/docker-compose.yaml.j2
+++ b/roles/composition-audiobookshelf/templates/docker-compose.yaml.j2
@@ -12,7 +12,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.audiobookshelf.rule=Host(`audiobookshelf.{{ domainname_infra }}`)"
       - "traefik.http.routers.audiobookshelf.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.audiobookshelf.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.audiobookshelf.loadbalancer.server.port=80"
     volumes:
       - "{{ shared_media_path }}/audiobooks:/audiobooks"

--- a/roles/composition-awfulwoman/templates/docker-compose.yaml.j2
+++ b/roles/composition-awfulwoman/templates/docker-compose.yaml.j2
@@ -13,6 +13,10 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.beta.rule=Host(`{{ domainname_personal }}`) || Host(`{{ vault_domainname_wc }}`) || Host(`{{ vault_domainname_se }}`)"
       - "traefik.http.routers.beta.tls=true"
+      # Deliberately NOT guarded by reverseproxy_wildcard_cert, unlike every
+      # other composition (#276). These are genuinely public domains, so the
+      # internal *.ewwww.eu wildcard can never cover them - this router needs
+      # real per-name ACME certs even on a host serving the wildcard by default.
       - "traefik.http.routers.beta.tls.certresolver=letsencrypt"
       - "traefik.http.services.beta.loadbalancer.server.port=80"
     volumes:

--- a/roles/composition-downloads/templates/docker-compose.yaml.j2
+++ b/roles/composition-downloads/templates/docker-compose.yaml.j2
@@ -16,7 +16,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.prowlarr.rule=Host(`prowlarr.{{ domainname_infra }}`)"
       - "traefik.http.routers.prowlarr.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.prowlarr.tls.certresolver=letsencrypt"
+{% endif %}
     volumes:
       - "{{ composition_config }}/prowlarr:/config"
       - /etc/localtime:/etc/localtime:ro
@@ -43,7 +45,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.bazarr.rule=Host(`bazarr.{{ domainname_infra }}`)"
       - "traefik.http.routers.bazarr.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.bazarr.tls.certresolver=letsencrypt"
+{% endif %}
     volumes:
       - "{{ composition_config }}/bazarr:/config"
       - "{{ shared_media_path }}:/data"
@@ -72,7 +76,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.radarr.rule=Host(`radarr.{{ domainname_infra }}`)"
       - "traefik.http.routers.radarr.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.radarr.tls.certresolver=letsencrypt"
+{% endif %}
     volumes:
       - "{{ composition_config }}/radarr:/config"
       - "{{ shared_media_path }}:/data"
@@ -107,7 +113,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.lidarr.rule=Host(`lidarr.{{ domainname_infra }}`)"
       - "traefik.http.routers.lidarr.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.lidarr.tls.certresolver=letsencrypt"
+{% endif %}
     volumes:
       - "{{ composition_config }}/lidarr:/config"
       - "{{ shared_media_path }}:/data"
@@ -141,7 +149,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.sonarr.rule=Host(`sonarr.{{ domainname_infra }}`)"
       - "traefik.http.routers.sonarr.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.sonarr.tls.certresolver=letsencrypt"
+{% endif %}
     volumes:
       - "{{ composition_config }}/sonarr:/config"
       - "{{ shared_media_path }}:/data"
@@ -243,19 +253,25 @@ services:
       - "traefik.http.routers.gluetun.service=gluetun"
       - "traefik.http.services.gluetun.loadbalancer.server.port=8000"
       - "traefik.http.routers.gluetun.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.gluetun.tls.certresolver=letsencrypt"
+{% endif %}
       # Qbittorrent
       - "traefik.http.routers.qbittorrent.rule=Host(`qbittorrent.{{ domainname_infra }}`)"
       - "traefik.http.routers.qbittorrent.service=qbittorrent"
       - "traefik.http.services.qbittorrent.loadbalancer.server.port=8080"
       - "traefik.http.routers.qbittorrent.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.qbittorrent.tls.certresolver=letsencrypt"
+{% endif %}
       # Transmission
       - "traefik.http.routers.transmission.rule=Host(`transmission.{{ domainname_infra }}`)"
       - "traefik.http.routers.transmission.service=transmission"
       - "traefik.http.services.transmission.loadbalancer.server.port=9091"
       - "traefik.http.routers.transmission.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.transmission.tls.certresolver=letsencrypt"
+{% endif %}
     volumes:
       - "{{ composition_config }}/gluetun:/gluetun"
       - "{{ composition_config }}/gluetun/config.toml:/gluetun/auth/config.toml"
@@ -292,7 +308,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.librofm.rule=Host(`librofm.{{ domainname_infra }}`)"
       - "traefik.http.routers.librofm.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.librofm.tls.certresolver=letsencrypt"
+{% endif %}
     volumes:
       - "{{ shared_media_path }}/audiobooks:/media"
       - "{{ composition_config }}/librofm:/data"
@@ -313,7 +331,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.jellyseerr.rule=Host(`jellyseerr.{{ domainname_infra }}`)"
       - "traefik.http.routers.jellyseerr.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.jellyseerr.tls.certresolver=letsencrypt"
+{% endif %}
     ports:
       - "5055:5055"
     volumes:

--- a/roles/composition-finances/templates/docker-compose.yaml.j2
+++ b/roles/composition-finances/templates/docker-compose.yaml.j2
@@ -13,7 +13,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.firefly.rule=Host(`firefly.{{ domainname_infra }}`)"
       - "traefik.http.routers.firefly.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.firefly.tls.certresolver=letsencrypt"
+{% endif %}
     volumes:
       - "{{ composition_config }}/firefly-upload:/var/www/html/storage/upload"
       - /etc/localtime:/etc/localtime:ro
@@ -73,7 +75,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.firefly-importer.rule=Host(`firefly-importer.{{ domainname_infra }}`)"
       - "traefik.http.routers.firefly-importer.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.firefly-importer.tls.certresolver=letsencrypt"
+{% endif %}
     networks:
       - "{{ default_docker_network }}"
     depends_on:

--- a/roles/composition-freshrss/templates/docker-compose.yaml.j2
+++ b/roles/composition-freshrss/templates/docker-compose.yaml.j2
@@ -12,7 +12,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.freshrss.rule=Host(`freshrss.{{ domainname_infra }}`)"
       - "traefik.http.routers.freshrss.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.freshrss.tls.certresolver=letsencrypt"
+{% endif %}
     volumes:
       - "{{ composition_config }}:/config"
       - /etc/localtime:/etc/localtime:ro

--- a/roles/composition-gateway/templates/docker-compose.yaml.j2
+++ b/roles/composition-gateway/templates/docker-compose.yaml.j2
@@ -13,7 +13,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.{{ composition_name }}.rule=Host(`{{ composition_name }}.{{ domainname_infra }}`)"
       - "traefik.http.routers.{{ composition_name }}.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.{{ composition_name }}.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.{{ composition_name }}.loadbalancer.server.port=4000"
     networks:
       - "{{ default_docker_network }}"

--- a/roles/composition-get-iplayer/templates/docker-compose.yaml.j2
+++ b/roles/composition-get-iplayer/templates/docker-compose.yaml.j2
@@ -10,7 +10,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.iplayer.rule=Host(`iplayer.{{ domainname_infra }}`)"
       - "traefik.http.routers.iplayer.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.iplayer.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.iplayer.loadbalancer.server.port=1935"
     volumes:
       - "{{ composition_config }}:/config"

--- a/roles/composition-gitea/templates/docker-compose.yaml.j2
+++ b/roles/composition-gitea/templates/docker-compose.yaml.j2
@@ -23,7 +23,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.gitea.rule=Host(`gitea.{{ domainname_infra }}`)"
       - "traefik.http.routers.gitea.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.gitea.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.gitea.loadbalancer.server.port=3000"
     volumes:
       - "{{ composition_config }}/gitea:/data"

--- a/roles/composition-grafana/templates/docker-compose.yaml.j2
+++ b/roles/composition-grafana/templates/docker-compose.yaml.j2
@@ -16,7 +16,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.{{ composition_grafana_container_name }}.rule=Host(`{{ composition_grafana_subdomain }}.{{ domainname_infra }}`)"
       - "traefik.http.routers.{{ composition_grafana_container_name }}.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.{{ composition_grafana_container_name }}.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.{{ composition_grafana_container_name }}.loadbalancer.server.port=3000"
 {% endif %}
     networks:

--- a/roles/composition-homeassistant-personal/templates/docker-compose.yaml.j2
+++ b/roles/composition-homeassistant-personal/templates/docker-compose.yaml.j2
@@ -10,7 +10,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.homeassistant-personal.rule=Host(`ha-personal.{{ domainname_infra }}`)"
       - "traefik.http.routers.homeassistant-personal.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.homeassistant-personal.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.homeassistant-personal.loadbalancer.server.port=8123"
     volumes:
       - "{{ composition_config }}/homeassistant:/config"

--- a/roles/composition-homepage/templates/docker-compose.yaml.j2
+++ b/roles/composition-homepage/templates/docker-compose.yaml.j2
@@ -12,7 +12,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.homepage.rule=Host(`home.{{ domainname_infra }}`) || Host(`{{ domainname_infra }}`) || Host(`www.{{ domainname_infra }}`)"
       - "traefik.http.routers.homepage.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.homepage.tls.certresolver=letsencrypt"
+{% endif %}
       # - "homepage.group=GROUP"
       # - "homepage.name=SUBDOMAIN"
       # - "homepage.href=https://SUBDOMAIN.{{ domainname_infra }}"

--- a/roles/composition-immich/templates/docker-compose.yaml.j2
+++ b/roles/composition-immich/templates/docker-compose.yaml.j2
@@ -28,7 +28,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.immich.rule=Host(`immich.{{ domainname_infra }}`)"
       - "traefik.http.routers.immich.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.immich.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.immich.loadbalancer.server.port=2283"
     healthcheck:
       disable: false

--- a/roles/composition-iplayarr/templates/docker-compose.yaml.j2
+++ b/roles/composition-iplayarr/templates/docker-compose.yaml.j2
@@ -10,7 +10,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.iplayarr.rule=Host(`iplayarr.{{ domainname_infra }}`)"
       - "traefik.http.routers.iplayarr.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.iplayarr.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.iplayarr.loadbalancer.server.port=4404"
     volumes:
       - "{{ iplayarr_downloads }}/shows:/data/shows"

--- a/roles/composition-jarvis/templates/docker-compose.yaml.j2
+++ b/roles/composition-jarvis/templates/docker-compose.yaml.j2
@@ -20,7 +20,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.{{ composition_name }}.rule=Host(`{{ composition_name }}.{{ domainname_infra }}`)"
       - "traefik.http.routers.{{ composition_name }}.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.{{ composition_name }}.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.{{ composition_name }}.loadbalancer.server.port=8080"
     volumes:
       - "{{ composition_config }}/state:/app/state"

--- a/roles/composition-jellyfin/templates/docker-compose.yaml.j2
+++ b/roles/composition-jellyfin/templates/docker-compose.yaml.j2
@@ -12,7 +12,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.jellyfin.rule=Host(`jellyfin.{{ domainname_infra }}`)"
       - "traefik.http.routers.jellyfin.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.jellyfin.tls.certresolver=letsencrypt"
+{% endif %}
     volumes:
       - "{{ composition_config }}/config:/config"
       - "{{ composition_config }}/cache:/cache"

--- a/roles/composition-karakeep/templates/docker-compose.yaml.j2
+++ b/roles/composition-karakeep/templates/docker-compose.yaml.j2
@@ -13,7 +13,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.karakeep.rule=Host(`karakeep.{{ domainname_infra }}`)"
       - "traefik.http.routers.karakeep.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.karakeep.tls.certresolver=letsencrypt"
+{% endif %}
     volumes:
       - "{{ composition_config }}/karakeep:/data"
     networks:

--- a/roles/composition-kiwix/templates/docker-compose.yaml.j2
+++ b/roles/composition-kiwix/templates/docker-compose.yaml.j2
@@ -17,7 +17,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.kiwix.rule=Host(`kiwix.{{ domainname_infra }}`)"
       - "traefik.http.routers.kiwix.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.kiwix.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.kiwix.loadbalancer.server.port=8080"
     volumes:
       - "{{ composition_kiwix_zim_path }}:/data:ro"

--- a/roles/composition-ladder/templates/docker-compose.yaml.j2
+++ b/roles/composition-ladder/templates/docker-compose.yaml.j2
@@ -12,7 +12,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.ladder.rule=Host(`ladder.{{ domainname_infra }}`)"
       - "traefik.http.routers.ladder.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.ladder.tls.certresolver=letsencrypt"
+{% endif %}
     volumes:
       - "{{ composition_config }}/ruleset.yaml:/app/ruleset.yaml"
       # - "{{ composition_config }}/handlers/form.html:/app/form.html"

--- a/roles/composition-libretranslate/templates/docker-compose.yaml.j2
+++ b/roles/composition-libretranslate/templates/docker-compose.yaml.j2
@@ -14,7 +14,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.libretranslate.rule=Host(`translate.{{ domainname_infra }}`)"
       - "traefik.http.routers.libretranslate.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.libretranslate.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.libretranslate.loadbalancer.server.port=5000"
     volumes:
       - "{{ composition_config }}/models:/home/libretranslate/.local:rw"

--- a/roles/composition-llm-inference-calculator/templates/docker-compose.yaml.j2
+++ b/roles/composition-llm-inference-calculator/templates/docker-compose.yaml.j2
@@ -10,7 +10,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.llmcalc.rule=Host(`llmcalc.{{ domainname_infra }}`)"
       - "traefik.http.routers.llmcalc.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.llmcalc.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.llmcalc.loadbalancer.server.port=80"
     volumes:
       - /etc/localtime:/etc/localtime:ro

--- a/roles/composition-logtide/templates/docker-compose.yaml.j2
+++ b/roles/composition-logtide/templates/docker-compose.yaml.j2
@@ -66,7 +66,9 @@ services:
       - "traefik.http.routers.logtide-api.rule=Host(`{{ composition_dns_subdomains[0] }}.{{ domainname_infra }}`) && PathPrefix(`/api`)"
       - "traefik.http.routers.logtide-api.service=logtide-api"
       - "traefik.http.routers.logtide-api.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.logtide-api.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.logtide-api.loadbalancer.server.port={{ composition_logtide_backend_port }}"
 {% endif %}
     networks:
@@ -107,7 +109,9 @@ services:
       - "traefik.http.routers.logtide-ui.rule=Host(`{{ composition_dns_subdomains[0] }}.{{ domainname_infra }}`)"
       - "traefik.http.routers.logtide-ui.service=logtide-ui"
       - "traefik.http.routers.logtide-ui.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.logtide-ui.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.logtide-ui.loadbalancer.server.port={{ composition_logtide_frontend_port }}"
 {% endif %}
     depends_on:

--- a/roles/composition-loki/templates/docker-compose.yaml.j2
+++ b/roles/composition-loki/templates/docker-compose.yaml.j2
@@ -15,7 +15,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.{{ composition_loki_container_name }}.rule=Host(`{{ composition_dns_subdomains[0] }}.{{ domainname_infra }}`)"
       - "traefik.http.routers.{{ composition_loki_container_name }}.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.{{ composition_loki_container_name }}.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.{{ composition_loki_container_name }}.loadbalancer.server.port=3100"
 {% endif %}
     networks:

--- a/roles/composition-mcp-kagisearch/templates/docker-compose.yaml.j2
+++ b/roles/composition-mcp-kagisearch/templates/docker-compose.yaml.j2
@@ -11,7 +11,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.mcp-kagisearch.rule=Host(`kagimcp.{{ domainname_infra }}`)"
       - "traefik.http.routers.mcp-kagisearch.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.mcp-kagisearch.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.mcp-kagisearch.loadbalancer.server.port=8000"
     networks:
       - "{{ default_docker_network }}"

--- a/roles/composition-mcp-openzim/templates/docker-compose.yaml.j2
+++ b/roles/composition-mcp-openzim/templates/docker-compose.yaml.j2
@@ -17,7 +17,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.openzim-mcp.rule=Host(`zim.{{ domainname_infra }}`)"
       - "traefik.http.routers.openzim-mcp.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.openzim-mcp.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.openzim-mcp.loadbalancer.server.port=8000"
     volumes:
       - "{{ composition_openzim_mcp_zim_path }}:/data:ro"

--- a/roles/composition-mcp-searxng/templates/docker-compose.yaml.j2
+++ b/roles/composition-mcp-searxng/templates/docker-compose.yaml.j2
@@ -10,7 +10,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.mcp-searxng.rule=Host(`searchmcp.{{ domainname_infra }}`)"
       - "traefik.http.routers.mcp-searxng.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.mcp-searxng.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.mcp-searxng.loadbalancer.server.port=3000"
     networks:
       - "{{ default_docker_network }}"

--- a/roles/composition-mcp-weather/templates/docker-compose.yaml.j2
+++ b/roles/composition-mcp-weather/templates/docker-compose.yaml.j2
@@ -12,7 +12,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.mcp-weather.rule=Host(`weathermcp.{{ domainname_infra }}`)"
       - "traefik.http.routers.mcp-weather.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.mcp-weather.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.mcp-weather.loadbalancer.server.port={{ composition_mcp_weather_port }}"
     networks:
       - "{{ default_docker_network }}"

--- a/roles/composition-memorybank/templates/docker-compose.yaml.j2
+++ b/roles/composition-memorybank/templates/docker-compose.yaml.j2
@@ -25,7 +25,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.memorybank.rule=Host(`memorybank.{{ domainname_infra }}`)"
       - "traefik.http.routers.memorybank.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.memorybank.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.memorybank.loadbalancer.server.port=80"
     networks:
       - "{{ default_docker_network }}"

--- a/roles/composition-motioneye/templates/docker-compose.yaml.j2
+++ b/roles/composition-motioneye/templates/docker-compose.yaml.j2
@@ -16,7 +16,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.motioneye.rule=Host(`motioneye.{{ ansible_facts['hostname'] }}.{{ domainname_infra }}`)"
       - "traefik.http.routers.motioneye.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.motioneye.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.motioneye.loadbalancer.server.port=8765"
     volumes:
       -  "{{ composition_config }}/shared:/shared"

--- a/roles/composition-n8n/templates/docker-compose.yaml.j2
+++ b/roles/composition-n8n/templates/docker-compose.yaml.j2
@@ -9,7 +9,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.n8n.rule=Host(`n8n.{{ domainname_infra }}`)"
       - "traefik.http.routers.n8n.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.n8n.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.n8n.loadbalancer.server.port=5678"
     volumes:
       - "{{ composition_config }}/n8n-data:/home/node/.n8n"

--- a/roles/composition-nabu/templates/docker-compose.yaml.j2
+++ b/roles/composition-nabu/templates/docker-compose.yaml.j2
@@ -19,7 +19,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.{{ composition_name }}.rule=Host(`{{ composition_name }}.{{ domainname_infra }}`)"
       - "traefik.http.routers.{{ composition_name }}.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.{{ composition_name }}.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.{{ composition_name }}.loadbalancer.server.port=8080"
     volumes:
       - "{{ composition_config }}/state:/app/state"

--- a/roles/composition-nominatim/templates/docker-compose.yaml.j2
+++ b/roles/composition-nominatim/templates/docker-compose.yaml.j2
@@ -14,7 +14,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.nominatim.rule=Host(`nominatim.{{ domainname_infra }}`)"
       - "traefik.http.routers.nominatim.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.nominatim.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.nominatim.loadbalancer.server.port=8080"
     volumes:
       - "/fastpool/shared/nominatim:/var/lib/postgresql/16/main"

--- a/roles/composition-oggcamp/templates/docker-compose.yaml.j2
+++ b/roles/composition-oggcamp/templates/docker-compose.yaml.j2
@@ -9,7 +9,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.oggcamp.rule=Host(`{{ composition_oggcamp_domain }}`)"
       - "traefik.http.routers.oggcamp.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.oggcamp.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.oggcamp.loadbalancer.server.port=80"
     volumes:
       - "{{ composition_config }}/repo/public:/usr/share/nginx/html:ro"

--- a/roles/composition-open-webui/templates/docker-compose.yaml.j2
+++ b/roles/composition-open-webui/templates/docker-compose.yaml.j2
@@ -10,7 +10,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.open-webui.rule=Host(`chat.{{ domainname_infra }}`)"
       - "traefik.http.routers.open-webui.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.open-webui.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.open-webui.loadbalancer.server.port=8080"
     volumes:
       - "{{ composition_config }}/data:/app/backend/data"

--- a/roles/composition-owntracks/templates/docker-compose.yaml.j2
+++ b/roles/composition-owntracks/templates/docker-compose.yaml.j2
@@ -12,7 +12,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.owntracks-recorder.rule=Host(`owntracks-recorder.{{ domainname_infra }}`)"
       - "traefik.http.routers.owntracks-recorder.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.owntracks-recorder.tls.certresolver=letsencrypt"
+{% endif %}
     volumes:
       - "{{ composition_config }}/config:/config"
       - "{{ composition_config }}/store:/store"
@@ -41,7 +43,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.owntracks-frontend.rule=Host(`owntracks.{{ domainname_infra }}`)"
       - "traefik.http.routers.owntracks-frontend.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.owntracks-frontend.tls.certresolver=letsencrypt"
+{% endif %}
     volumes:
       - "{{ composition_config }}/config:/config"
       - "{{ composition_config }}/store:/store"

--- a/roles/composition-paperless-ngx/templates/docker-compose.yaml.j2
+++ b/roles/composition-paperless-ngx/templates/docker-compose.yaml.j2
@@ -86,7 +86,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.paperless.rule=Host(`paperless.{{ domainname_infra }}`)"
       - "traefik.http.routers.paperless.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.paperless.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.paperless.loadbalancer.server.port=8000"
     healthcheck:
       test: ["CMD", "curl", "-fs", "-S", "--max-time", "2", "http://localhost:8000"]

--- a/roles/composition-pixelfed/templates/docker-compose.yaml.j2
+++ b/roles/composition-pixelfed/templates/docker-compose.yaml.j2
@@ -46,10 +46,14 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.pixelfed.rule=Host(`{{ pixelfed_app_domain }}`)"
       - "traefik.http.routers.pixelfed.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.pixelfed.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.routers.pixelfed-admin.rule=Host(`{{ pixelfed_admin_domain }}`)"
       - "traefik.http.routers.pixelfed-admin.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.pixelfed-admin.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.routers.pixelfed-admin.service=pixelfed"
       - "traefik.http.services.pixelfed.loadbalancer.server.port=8080"
     volumes:

--- a/roles/composition-reverseproxy/defaults/main.yaml
+++ b/roles/composition-reverseproxy/defaults/main.yaml
@@ -9,12 +9,14 @@ composition_dns_subdomains:
   - "whoami-{host}"
   - "traefik-{host}"
 
-reverseproxy_use_letsencrypt: true
-# Set alongside reverseproxy_use_letsencrypt: false to serve the internal
-# wildcard cert (client-cert-distribution, #269) as Traefik's default cert
-# instead of Traefik's own per-host ACME. Mounts reverseproxy_wildcard_cert_dir
-# into the container and requires "wildcard-cert" in traefik_providers.
-reverseproxy_wildcard_cert: false
+# reverseproxy_use_letsencrypt and reverseproxy_wildcard_cert are deliberately
+# NOT defaulted here - they live in inventory/group_vars/all.yaml, because every
+# composition role that emits a certresolver label needs them in scope and role
+# defaults are role-scoped. See #276.
+#
+# reverseproxy_wildcard_cert: true mounts this directory into the container and
+# requires "wildcard-cert" in traefik_providers to actually install the bundle
+# (client-cert-distribution, #269) as Traefik's default certificate.
 reverseproxy_wildcard_cert_dir: /etc/ssl/internal-wildcard
 reverseproxy_catchall: false
 reverseproxy_statuspage: false

--- a/roles/composition-reverseproxy/files/prune-acme-internal-certs.py
+++ b/roles/composition-reverseproxy/files/prune-acme-internal-certs.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Remove internal-domain certificates from a Traefik ACME store (#276).
+
+On a host that serves the internal wildcard as its default certificate, no
+router asks ACME for an internal name any more. Certificates issued for those
+names before the flip still linger in acme.json, and Traefik does not care that
+nothing references them:
+
+  - its renewal loop walks the whole store, so they keep getting renewed -
+    exactly the DNS-01 challenge race #262 exists to remove; and
+  - an exact-name match beats a wildcard during SNI selection, so the stale
+    cert is served in preference to the wildcard it was supposed to replace.
+
+Both stop once the entries are gone. Nothing re-creates them: the certresolver
+labels for internal names are guarded on reverseproxy_wildcard_cert.
+
+Usage:
+    prune-acme-internal-certs.py <store.json> <internal-suffix> [--apply]
+
+Without --apply, reports what it would remove and changes nothing. Prints
+"REMOVED=<n>" either way, so the caller can drive changed_when off it.
+"""
+
+import json
+import os
+import stat
+import sys
+import tempfile
+
+
+def is_internal(cert: dict, suffix: str) -> bool:
+    """True if every name on the cert sits under the internal suffix.
+
+    Deliberately conservative: a cert mixing internal and public names would be
+    doing double duty for something public, so it is left alone and reported.
+    """
+    domain = cert.get("domain") or {}
+    names = [domain.get("main")] + list(domain.get("sans") or [])
+    names = [n for n in names if n]
+    if not names:
+        return False
+    return all(n == suffix or n.endswith("." + suffix) for n in names)
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    apply_changes = "--apply" in sys.argv[1:]
+
+    if len(args) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    store_path, suffix = args
+
+    if not os.path.exists(store_path) or os.path.getsize(store_path) == 0:
+        print("REMOVED=0")
+        print(f"store {store_path} is absent or empty; nothing to do")
+        return 0
+
+    with open(store_path) as handle:
+        store = json.load(handle)
+
+    removed = []
+    mixed = []
+
+    for resolver, section in store.items():
+        certs = section.get("Certificates")
+        if not certs:
+            continue
+
+        keep = []
+        for cert in certs:
+            domain = cert.get("domain") or {}
+            names = [domain.get("main")] + list(domain.get("sans") or [])
+            names = [n for n in names if n]
+
+            if is_internal(cert, suffix):
+                removed.append(f"{resolver}: {', '.join(names)}")
+                continue
+
+            if any(n == suffix or n.endswith("." + suffix) for n in names):
+                mixed.append(f"{resolver}: {', '.join(names)}")
+
+            keep.append(cert)
+
+        section["Certificates"] = keep
+
+    print(f"REMOVED={len(removed)}")
+    for line in removed:
+        print(f"  - {line}")
+    for line in mixed:
+        print(f"  ! kept (mixes internal and public names): {line}")
+
+    if not removed or not apply_changes:
+        return 0
+
+    # Atomic replace inside the same directory, preserving the original's
+    # ownership and mode - the file holds private keys.
+    original = os.stat(store_path)
+    directory = os.path.dirname(store_path) or "."
+    handle, temp_path = tempfile.mkstemp(dir=directory)
+    try:
+        with os.fdopen(handle, "w") as out:
+            json.dump(store, out, indent=2)
+        os.chmod(temp_path, stat.S_IMODE(original.st_mode))
+        try:
+            os.chown(temp_path, original.st_uid, original.st_gid)
+        except PermissionError:
+            pass
+        os.replace(temp_path, store_path)
+    except Exception:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/roles/composition-reverseproxy/tasks/main.yaml
+++ b/roles/composition-reverseproxy/tasks/main.yaml
@@ -72,6 +72,53 @@
     group: "{{ ansible_user }}"
     mode: '0600'
 
+# Dual-mode hosts only (#276). Where the wildcard is the default cert but the
+# ACME resolver is still alive for genuinely public names, certificates issued
+# for internal names before the flip have to be evicted from the store:
+# Traefik's renewal loop walks the whole store regardless of what any router
+# references, and an exact-name match beats the wildcard during SNI selection.
+# Nothing re-creates them - the internal certresolver labels are guarded.
+- name: "Prune internal-domain certs from the ACME store"
+  when:
+    - reverseproxy_use_letsencrypt
+    - reverseproxy_wildcard_cert
+  block:
+    - name: "Check the ACME store for internal-domain certs"
+      become: true
+      ansible.builtin.script:
+        cmd: >-
+          files/prune-acme-internal-certs.py
+          {{ composition_config }}/letsencrypt/acme.json
+          {{ domainname_infra }}
+      register: _acme_prune_check
+      changed_when: false
+
+    - name: "Stop Traefik before rewriting the ACME store"
+      # Traefik holds the store in memory and flushes it back on any
+      # certificate change, so it would undo an edit made underneath it.
+      become: true
+      ansible.builtin.command:
+        cmd: docker stop traefik
+      register: _acme_prune_stop
+      changed_when: _acme_prune_stop.rc == 0
+      failed_when:
+        - _acme_prune_stop.rc != 0
+        - "'No such container' not in _acme_prune_stop.stderr"
+      when: "'REMOVED=0' not in _acme_prune_check.stdout"
+
+    - name: "Remove internal-domain certs from the ACME store"
+      become: true
+      ansible.builtin.script:
+        cmd: >-
+          files/prune-acme-internal-certs.py
+          {{ composition_config }}/letsencrypt/acme.json
+          {{ domainname_infra }}
+          --apply
+      register: _acme_prune_apply
+      changed_when: "'REMOVED=0' not in _acme_prune_apply.stdout"
+      when: "'REMOVED=0' not in _acme_prune_check.stdout"
+      notify: Restart Traefik
+
 # Custom http responses
 
 - name: Create directories

--- a/roles/composition-reverseproxy/templates/docker-compose.yaml.j2
+++ b/roles/composition-reverseproxy/templates/docker-compose.yaml.j2
@@ -57,7 +57,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.whoami.rule=Host(`whoami-{{ host_name }}.{{ domainname_infra }}`)"
       - "traefik.http.routers.whoami.tls=true"
-{% if reverseproxy_use_letsencrypt %}
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.whoami.tls.certresolver=letsencrypt"
 {% endif %}
     volumes:
@@ -89,14 +89,14 @@ services:
       - "traefik.http.routers.dashboard.rule=Host(`{{ reverseproxy_traefik_domain}}`)"
       - "traefik.http.routers.dashboard.service=dashboard@internal"
       - "traefik.http.routers.dashboard.tls=true"
-{% if reverseproxy_use_letsencrypt %}
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.dashboard.tls.certresolver=letsencrypt"
 {% endif %}
       # Allow API access via traefik.{{ansible_facts['hostname']}}.{{ domainname_infra }}
       - "traefik.http.routers.api.rule=Host(`{{ reverseproxy_traefik_domain}}`) && PathPrefix(`/api`)"
       - "traefik.http.routers.api.service=api@internal"
       - "traefik.http.routers.api.tls=true"
-{% if reverseproxy_use_letsencrypt %}
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.api.tls.certresolver=letsencrypt"
 {% endif %}
     volumes:

--- a/roles/composition-reverseproxy/templates/providers/esphome.yaml
+++ b/roles/composition-reverseproxy/templates/providers/esphome.yaml
@@ -9,8 +9,16 @@ http:
     esphome:
       service: esphome
       rule: "Host(`esphome.{{ domainname_infra }}`)"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       tls:
         certresolver: letsencrypt
+{% else %}
+      # Empty mapping, not an omitted key: the router still terminates TLS,
+      # it just takes the default cert (the internal wildcard) instead of
+      # asking ACME. Guarded because this is an internal name; the public
+      # providers (gotosocial, personalsite) stay unguarded. See #276.
+      tls: {}
+{% endif %}
       entrypoints:
         - web
         - websecure

--- a/roles/composition-reverseproxy/templates/providers/gateway.yaml
+++ b/roles/composition-reverseproxy/templates/providers/gateway.yaml
@@ -9,8 +9,16 @@ http:
     gateway:
       service: gateway
       rule: "Host(`gateway.{{ domainname_infra }}`)"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       tls:
         certresolver: letsencrypt
+{% else %}
+      # Empty mapping, not an omitted key: the router still terminates TLS,
+      # it just takes the default cert (the internal wildcard) instead of
+      # asking ACME. Guarded because this is an internal name; the public
+      # providers (gotosocial, personalsite) stay unguarded. See #276.
+      tls: {}
+{% endif %}
       entrypoints:
         - web
         - websecure

--- a/roles/composition-reverseproxy/templates/providers/homeassistant.yaml
+++ b/roles/composition-reverseproxy/templates/providers/homeassistant.yaml
@@ -9,8 +9,16 @@ http:
     homeassistant:
       service: homeassistant
       rule: "Host(`homeassistant.{{ domainname_infra }}`)"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       tls:
         certresolver: letsencrypt
+{% else %}
+      # Empty mapping, not an omitted key: the router still terminates TLS,
+      # it just takes the default cert (the internal wildcard) instead of
+      # asking ACME. Guarded because this is an internal name; the public
+      # providers (gotosocial, personalsite) stay unguarded. See #276.
+      tls: {}
+{% endif %}
       entrypoints:
         - web
         - websecure

--- a/roles/composition-reverseproxy/templates/providers/immich.yaml
+++ b/roles/composition-reverseproxy/templates/providers/immich.yaml
@@ -9,8 +9,16 @@ http:
     immich:
       service: immich
       rule: "Host(`immich.{{ domainname_infra }}`)"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       tls:
         certresolver: letsencrypt
+{% else %}
+      # Empty mapping, not an omitted key: the router still terminates TLS,
+      # it just takes the default cert (the internal wildcard) instead of
+      # asking ACME. Guarded because this is an internal name; the public
+      # providers (gotosocial, personalsite) stay unguarded. See #276.
+      tls: {}
+{% endif %}
       entrypoints:
         - websecure
         # websecure:

--- a/roles/composition-reverseproxy/templates/providers/musicassistant.yaml
+++ b/roles/composition-reverseproxy/templates/providers/musicassistant.yaml
@@ -9,8 +9,16 @@ http:
     musicassistant:
       service: musicassistant
       rule: "Host(`musicassistant.{{ domainname_infra }}`)"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       tls:
         certresolver: letsencrypt
+{% else %}
+      # Empty mapping, not an omitted key: the router still terminates TLS,
+      # it just takes the default cert (the internal wildcard) instead of
+      # asking ACME. Guarded because this is an internal name; the public
+      # providers (gotosocial, personalsite) stay unguarded. See #276.
+      tls: {}
+{% endif %}
       entrypoints:
         - web
         - websecure

--- a/roles/composition-reverseproxy/templates/providers/vm-routes.yaml.j2
+++ b/roles/composition-reverseproxy/templates/providers/vm-routes.yaml.j2
@@ -10,9 +10,14 @@ http:
       service: {{ route.name }}-service
       entryPoints:
         - websecure
-{% if reverseproxy_use_letsencrypt %}
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       tls:
         certResolver: letsencrypt
+{% else %}
+      # Empty mapping, not an omitted key: this router only listens on
+      # websecure, so it still has to terminate TLS - it just takes the
+      # default cert (the internal wildcard) instead of asking ACME. See #276.
+      tls: {}
 {% endif %}
 {% if route.middlewares is defined %}
       middlewares:

--- a/roles/composition-reverseproxy/templates/providers/watchyourlan.yaml
+++ b/roles/composition-reverseproxy/templates/providers/watchyourlan.yaml
@@ -9,8 +9,16 @@ http:
     watchyourlan:
       service: watchyourlan
       rule: "Host(`lan.{{ domainname_infra }}`)"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       tls:
         certresolver: letsencrypt
+{% else %}
+      # Empty mapping, not an omitted key: the router still terminates TLS,
+      # it just takes the default cert (the internal wildcard) instead of
+      # asking ACME. Guarded because this is an internal name; the public
+      # providers (gotosocial, personalsite) stay unguarded. See #276.
+      tls: {}
+{% endif %}
       entrypoints:
         - websecure
         # websecure:

--- a/roles/composition-searxng/templates/docker-compose.yaml.j2
+++ b/roles/composition-searxng/templates/docker-compose.yaml.j2
@@ -10,7 +10,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.searxng.rule=Host(`searxng.{{ domainname_infra }}`) || Host(`search.{{ domainname_infra }}`)"
       - "traefik.http.routers.searxng.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.searxng.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.searxng.loadbalancer.server.port=8080"
     volumes:
       - "{{ composition_config }}/searxng:/etc/searxng:rw"

--- a/roles/composition-syncthing/templates/docker-compose.yaml.j2
+++ b/roles/composition-syncthing/templates/docker-compose.yaml.j2
@@ -15,7 +15,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.syncthing.rule=Host(`syncthing-{{ host_name }}.{{ domainname_infra }}`)"
       - "traefik.http.routers.syncthing.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.syncthing.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.syncthing.loadbalancer.server.port=8384"
     restart: unless-stopped
     networks:

--- a/roles/composition-tubesync/templates/docker-compose.yaml.j2
+++ b/roles/composition-tubesync/templates/docker-compose.yaml.j2
@@ -16,7 +16,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.tubesync.rule=Host(`tubesync.{{ domainname_infra }}`)"
       - "traefik.http.routers.tubesync.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.tubesync.tls.certresolver=letsencrypt"
+{% endif %}
     networks:
       - "{{ default_docker_network }}"
 

--- a/roles/composition-uptime-kuma/templates/docker-compose.yaml.j2
+++ b/roles/composition-uptime-kuma/templates/docker-compose.yaml.j2
@@ -12,7 +12,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.uptime-kuma.rule=Host(`uptime-kuma.{{ domainname_infra }}`)"
       - "traefik.http.routers.uptime-kuma.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.uptime-kuma.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.uptime-kuma.loadbalancer.server.port=3001"
     volumes:
       - "{{ composition_config }}:/app/data"
@@ -40,7 +42,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.uptime-kuma-api.rule=Host(`{{ composition_dns_subdomains[1] }}.{{ domainname_infra }}`)"
       - "traefik.http.routers.uptime-kuma-api.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.uptime-kuma-api.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.uptime-kuma-api.loadbalancer.server.port=5001"
     networks:
       - "{{ default_docker_network }}"

--- a/roles/composition-vane/templates/docker-compose.yaml.j2
+++ b/roles/composition-vane/templates/docker-compose.yaml.j2
@@ -12,7 +12,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.vane.rule=Host(`vane.{{ domain_name }}`)"
       - "traefik.http.routers.vane.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.vane.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.vane.loadbalancer.server.port=3000"
     volumes:
       - "{{ composition_config }}/data:/home/vane/data"

--- a/roles/composition-victoriametrics/templates/docker-compose.yaml.j2
+++ b/roles/composition-victoriametrics/templates/docker-compose.yaml.j2
@@ -20,7 +20,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.{{ composition_victoriametrics_container_name }}.rule=Host(`{{ composition_dns_subdomains[0] }}.{{ domainname_infra }}`)"
       - "traefik.http.routers.{{ composition_victoriametrics_container_name }}.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.{{ composition_victoriametrics_container_name }}.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.{{ composition_victoriametrics_container_name }}.loadbalancer.server.port={{ composition_victoriametrics_port }}"
 {% endif %}
     networks:

--- a/roles/composition-vikunja/templates/docker-compose.yaml.j2
+++ b/roles/composition-vikunja/templates/docker-compose.yaml.j2
@@ -16,7 +16,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.vikunja.rule=Host(`vikunja.{{ domainname_infra }}`)"
       - "traefik.http.routers.vikunja.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.vikunja.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.vikunja.loadbalancer.server.port=3456"
     networks:
       - "{{ default_docker_network }}"

--- a/roles/composition-whoami/templates/docker-compose.yaml.j2
+++ b/roles/composition-whoami/templates/docker-compose.yaml.j2
@@ -11,7 +11,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.whoami.rule=Host(`whoami.{{ ansible_facts['hostname'] }}.{{ domainname_infra }}`)"
       - "traefik.http.routers.whoami.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.whoami.tls.certresolver=letsencrypt"
+{% endif %}
     volumes:
       - /etc/localtime:/etc/localtime:ro
     networks:

--- a/roles/composition-zfs-api/templates/docker-compose.yaml.j2
+++ b/roles/composition-zfs-api/templates/docker-compose.yaml.j2
@@ -17,7 +17,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.{{ composition_zfs_api_container_name }}.rule=Host(`zfs-api-{{ host_name }}.{{ domainname_infra }}`)"
       - "traefik.http.routers.{{ composition_zfs_api_container_name }}.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.{{ composition_zfs_api_container_name }}.tls.certresolver=letsencrypt"
+{% endif %}
       - "traefik.http.services.{{ composition_zfs_api_container_name }}.loadbalancer.server.port={{ composition_zfs_api_port }}"
 {% endif %}
     networks:

--- a/roles/composition-zigbee2mqtt/templates/docker-compose.yaml.j2
+++ b/roles/composition-zigbee2mqtt/templates/docker-compose.yaml.j2
@@ -13,7 +13,9 @@ services:
       - "traefik.http.services.zigbee2mqtt.loadbalancer.server.port=9091"
       - "traefik.http.routers.zigbee2mqtt.rule=Host(`zigbee2mqtt.{{ domainname_infra }}`)"
       - "traefik.http.routers.zigbee2mqtt.tls=true"
+{% if reverseproxy_use_letsencrypt and not reverseproxy_wildcard_cert %}
       - "traefik.http.routers.zigbee2mqtt.tls.certresolver=letsencrypt"
+{% endif %}
     group_add:
       - dialout
     devices:


### PR DESCRIPTION
Closes #276.

public01 is the one host that cannot do the clean on/off flip the other six got in #270/#271. Its internal management routers should serve the `*.ewwww.eu` wildcard like everywhere else, but the `letsencrypt` resolver has to stay alive for the genuinely public names the wildcard can never cover.

## What changed

`reverseproxy_use_letsencrypt` now means only *"the ACME resolver exists in `traefik.yaml`"* (plus its storage volume). `reverseproxy_wildcard_cert` independently decides whether internal routers ask ACME at all. Both true is public01's case.

Both flags move from `composition-reverseproxy`'s defaults to `inventory/group_vars/all.yaml` — role defaults are role-scoped, so they were not in scope inside `composition-zfs-api` and friends, which is exactly where the guard now lives. Values unchanged, and group_vars outranks role defaults, so the move itself is behaviour-neutral.

## Two premises in the issue turned out to be wrong

**`awfulwoman.com` is not served by the `personalsite.yaml` file provider.** That template is not in public01's `traefik_providers` and its own first line says it isn't in use. The live path is `composition-awfulwoman` running locally on public01, whose `beta` router also covers the two old redirect domains. So the scoped-ACME set is five public names, not two, and that router's certresolver label is deliberately left unguarded with a comment explaining why.

**Nearly every composition role hardcoded `certresolver=letsencrypt` with no guard.** That was harmless on the six already-flipped hosts only because the resolver block was gone, so Traefik logged `certificate resolver is not defined` and fell back to the default cert. public01 breaks that assumption: with the resolver alive, `zfs-api-vps-hetzner-public01.ewwww.eu` would have started doing real DNS-01 challenges against the `ewwww.eu` zone — exactly the race #262 exists to remove. Guarded across all ~50 templates, which also clears the spurious error logs on the other wildcard hosts.

## The config change alone did not satisfy AC 1

Deployed it and checked: internal names were **still** serving their old per-name certs. `acme.json` held 14 certificates, 11 of them internal `.ewwww.eu` names accumulated across earlier rounds of renaming. Traefik does not care that nothing references them:

- its renewal loop walks the whole store, so all 11 kept getting renewed; and
- an exact-name match beats a wildcard during SNI selection.

So the second commit adds a pruning task, gated on the dual-mode combination, that removes certificates whose names all sit under `domainname_infra`. Traefik is stopped first — it holds the store in memory and flushes it back on any certificate change, so an edit made underneath a running instance would be undone.

The script is conservative: a certificate mixing internal and public names is kept and reported rather than removed, since it must be doing double duty for something public. Rewrites atomically inside the same directory, preserving owner and mode; the file holds private keys.

Internal file providers (`esphome`, `gateway`, `immich`, `musicassistant`, `homeassistant`, `watchyourlan`) and `vm-routes` get the guard with an explicit `tls: {}` else-branch rather than an omitted key — those routers listen on `websecure` and must still terminate TLS, just with the default cert.

## Acceptance criteria

| AC | Result |
|---|---|
| Dashboard/api routers use the wildcard, single-label named | `traefik-vps-hetzner-public01.ewwww.eu` → `CN = *.ewwww.eu` |
| Public names still serve ACME certs, not the wildcard | `gts.awfulwoman.com`, `awfulwoman.com` (+ `whalecoiner.com`, `sonniesedge.co.uk` as SANs) each serve their own Let's Encrypt cert, 200 |
| No other router references the resolver | Only `config/providers/gotosocial.yaml`; `composition-awfulwoman`'s router does so from its own composition |
| Domain snapshot shows only the intended delta | `zfs-api-vps-hetzner-public01.ewwww.eu`: pinned Tailscale IP, 200, `CN=*.ewwww.eu`, from both vantages |

`reverseproxy_traefik_domain` already defaulted to the single-label `traefik-{host}` form from #271, so no rename was needed. public01's `compositions` entry keeps `labels: []`, so no `traefik-{host}` CNAME is registered — the router still flips to the wildcard, it just has no DNS name, per the existing host_vars comment that exposing the dashboard stays a deliberate call.

## Verification

Deployed to public01 and verified live, using `openssl` **without** `-k`:

- `acme.json`: 14 certs → 3, all public.
- `gts.awfulwoman.com` 200, `/.well-known/nodeinfo` 200 and the instance API responding, so federation discovery is intact. `awfulwoman.com` 200.
- Zero errors in Traefik's log since restart.
- Re-running the composition play is `changed=0`; a full `core.yaml` run is 223 ok / 3 changed / 0 failed, the 3 being `client-cert-distribution` re-downloading its candidate bundle.
- Regression on an already-flipped host: redeployed `zfs-api` to storage via `target_composition`. Label gone, wildcard served, no `certificate resolver is not defined` errors, `homeassistant.ewwww.eu` still 200 under full hostname verification.
- Prune script unit-tested against a fixture: dry run is read-only, apply is idempotent, account section and file mode preserved, mixed-name certs kept, empty/missing store handled.
- `pre-commit` and `pytest` (12 passed) clean.

Snapshot baseline files are deliberately left unrefreshed, as in #271 — they are the pre-#262 baseline and the diff against them is cumulative across #270–#272, not attributable to this change.

## Notes

- A pre-prune backup of the ACME store is on public01 at `/fastpool/compositions/reverseproxy/config/letsencrypt/acme.json.pre-276.bak`. It contains live private keys and sits in a `policy: critical` ZFS dataset — worth deleting once this is settled.
- Healthchecks.io still returns 403 on check creation, the same account-level symptom #271 saw. Caught by the role's rescue block; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
